### PR TITLE
GroovyScript compat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,6 +149,7 @@ repositories {
         url = uri("http://jenkins.usrv.eu:8081/nexus/content/groups/public/")
         isAllowInsecureProtocol = true
     }
+    mavenLocal()
 }
 
 dependencies {
@@ -177,6 +178,10 @@ dependencies {
         isTransitive = false
     }
 
+    compileOnlyApi("org.jetbrains:annotations:24.1.0")
+    annotationProcessor("org.jetbrains:annotations:24.1.0")
+
+    api("com.cleanroommc:groovyscript:1.0.0-SNAPSHOT-d") { isTransitive = false }
     implementation("CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.+")
     implementation(rfg.deobf("curse.maven:had-enough-items-557549:4810661"))
     implementation(rfg.deobf("curse.maven:zenutil-401178:5056679"))
@@ -195,7 +200,7 @@ dependencies {
     implementation(rfg.deobf("curse.maven:applied-energistics-2-223794:2747063"))
 //    implementation(rfg.deobf("curse.maven:ae2-extended-life-570458:4961400"))
 //    compileOnly(rfg.deobf("curse.maven:gregtech-293327:3266351"))
-    implementation(rfg.deobf("curse.maven:gregtech-ce-unofficial-557242:4799055"))
+    compileOnly(rfg.deobf("curse.maven:gregtech-ce-unofficial-557242:4799055"))
 
     // GeckoLib
     implementation(rfg.deobf("software.bernie.geckolib:geckolib-forge-1.12.2:3.0.31"))

--- a/src/main/java/github/kasuminova/mmce/common/event/machine/IEventHandler.java
+++ b/src/main/java/github/kasuminova/mmce/common/event/machine/IEventHandler.java
@@ -1,0 +1,19 @@
+package github.kasuminova.mmce.common.event.machine;
+
+import groovy.lang.Closure;
+import net.minecraftforge.fml.common.Optional;
+
+public interface IEventHandler<T> {
+
+    void invoke(T event);
+
+    @Optional.Method(modid = "groovyscript")
+    static <T> IEventHandler<T> of(Closure<?> listener) {
+        return listener::call;
+    }
+
+    @Optional.Method(modid = "crafttweaker")
+    static <T> IEventHandler<T> of(crafttweaker.util.IEventHandler<T> eventHandler) {
+        return eventHandler::handle;
+    }
+}

--- a/src/main/java/github/kasuminova/mmce/common/event/machine/MachineEvent.java
+++ b/src/main/java/github/kasuminova/mmce/common/event/machine/MachineEvent.java
@@ -1,13 +1,11 @@
 package github.kasuminova.mmce.common.event.machine;
 
 import crafttweaker.annotations.ZenRegister;
-import crafttweaker.util.IEventHandler;
 import github.kasuminova.mmce.common.handler.UpgradeMachineEventHandler;
 import github.kasuminova.mmce.common.helper.IMachineController;
 import hellfirepvp.modularmachinery.ModularMachinery;
 import hellfirepvp.modularmachinery.common.machine.DynamicMachine;
 import hellfirepvp.modularmachinery.common.tiles.base.TileMultiblockMachineController;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenGetter;
@@ -56,7 +54,7 @@ public class MachineEvent extends Event {
         }
 
         for (IEventHandler<MachineEvent> handler : handlers) {
-            handler.handle(this);
+            handler.invoke(this);
             if (isCanceled()) {
                 break;
             }

--- a/src/main/java/github/kasuminova/mmce/common/event/recipe/RecipeEvent.java
+++ b/src/main/java/github/kasuminova/mmce/common/event/recipe/RecipeEvent.java
@@ -1,7 +1,7 @@
 package github.kasuminova.mmce.common.event.recipe;
 
 import crafttweaker.annotations.ZenRegister;
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.machine.MachineEvent;
 import hellfirepvp.modularmachinery.common.crafting.ActiveMachineRecipe;
 import hellfirepvp.modularmachinery.common.crafting.helper.RecipeCraftingContext;
@@ -54,7 +54,7 @@ public class RecipeEvent extends MachineEvent {
             return;
         }
         for (IEventHandler<RecipeEvent> handler : handlers) {
-            handler.handle(this);
+            handler.invoke(this);
             if (isCanceled()) {
                 break;
             }

--- a/src/main/java/github/kasuminova/mmce/common/integration/groovyscript/GroovyMachine.java
+++ b/src/main/java/github/kasuminova/mmce/common/integration/groovyscript/GroovyMachine.java
@@ -1,0 +1,26 @@
+package github.kasuminova.mmce.common.integration.groovyscript;
+
+import com.cleanroommc.groovyscript.api.IScriptReloadable;
+import com.cleanroommc.groovyscript.registry.NamedRegistry;
+import net.minecraft.util.ResourceLocation;
+
+public class GroovyMachine extends NamedRegistry implements IScriptReloadable {
+
+    private final ResourceLocation name;
+
+    public GroovyMachine(ResourceLocation name) {
+        this.name = name;
+    }
+
+    @Override
+    public void onReload() {
+    }
+
+    @Override
+    public void afterScriptLoad() {
+    }
+
+    public GroovyRecipe recipeBuilder(String name) {
+        return new GroovyRecipe(this.name);
+    }
+}

--- a/src/main/java/github/kasuminova/mmce/common/integration/groovyscript/GroovyRecipe.java
+++ b/src/main/java/github/kasuminova/mmce/common/integration/groovyscript/GroovyRecipe.java
@@ -1,0 +1,843 @@
+package github.kasuminova.mmce.common.integration.groovyscript;
+
+import com.cleanroommc.groovyscript.api.GroovyLog;
+import com.cleanroommc.groovyscript.api.IIngredient;
+import com.cleanroommc.groovyscript.helper.ingredient.IngredientHelper;
+import com.cleanroommc.groovyscript.helper.ingredient.OreDictIngredient;
+import com.cleanroommc.groovyscript.helper.recipe.RecipeName;
+import com.cleanroommc.groovyscript.sandbox.ClosureHelper;
+import github.kasuminova.mmce.common.event.Phase;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
+import github.kasuminova.mmce.common.event.recipe.*;
+import github.kasuminova.mmce.common.util.concurrent.Action;
+import groovy.lang.Closure;
+import hellfirepvp.modularmachinery.ModularMachinery;
+import hellfirepvp.modularmachinery.common.base.Mods;
+import hellfirepvp.modularmachinery.common.crafting.PreparedRecipe;
+import hellfirepvp.modularmachinery.common.crafting.RecipeRegistry;
+import hellfirepvp.modularmachinery.common.crafting.helper.ComponentRequirement;
+import hellfirepvp.modularmachinery.common.crafting.helper.ComponentSelectorTag;
+import hellfirepvp.modularmachinery.common.crafting.requirement.*;
+import hellfirepvp.modularmachinery.common.data.Config;
+import hellfirepvp.modularmachinery.common.integration.crafttweaker.IngredientArrayPrimer;
+import hellfirepvp.modularmachinery.common.lib.RequirementTypesMM;
+import hellfirepvp.modularmachinery.common.machine.DynamicMachine;
+import hellfirepvp.modularmachinery.common.machine.IOType;
+import hellfirepvp.modularmachinery.common.machine.MachineRegistry;
+import hellfirepvp.modularmachinery.common.modifier.RecipeModifier;
+import hellfirepvp.modularmachinery.common.util.SmartInterfaceType;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import mekanism.api.gas.GasStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.Optional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class GroovyRecipe implements PreparedRecipe {
+
+    protected String name;
+    protected final ResourceLocation machineName;
+    private int tickTime = 100, priority = 0;
+    private boolean doesVoidPerTick = false;
+
+    private final List<ComponentRequirement<?, ?>> components = new ArrayList<>();
+    private final List<Action> needAfterInitActions = new ArrayList<>();
+    private final List<String> toolTipList = new ArrayList<>();
+    private final Map<Class<?>, List<IEventHandler<RecipeEvent>>> recipeEventHandlers = new Object2ObjectOpenHashMap<>();
+
+    private boolean parallelized = Config.recipeParallelizeEnabledByDefault;
+    private int maxThreads = -1;
+    private String threadName = "";
+    private ComponentRequirement<?, ?> lastComponent = null;
+
+    public GroovyRecipe(ResourceLocation owningMachine) {
+        this.machineName = owningMachine;
+    }
+
+    public GroovyRecipe name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public GroovyRecipe time(int time) {
+        this.tickTime = time;
+        return this;
+    }
+
+    public GroovyRecipe priority(int priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    public GroovyRecipe cancelIfPerTickFails(boolean b) {
+        this.doesVoidPerTick = b;
+        return this;
+    }
+
+    public GroovyRecipe parallelizeUnaffected(boolean unaffected) {
+        if (lastComponent instanceof ComponentRequirement.Parallelizable parallelizable) {
+            parallelizable.setParallelizeUnaffected(unaffected);
+        } else {
+            GroovyLog.get().warn("Target " + lastComponent.getClass() + " cannot be parallelized!");
+        }
+        return this;
+    }
+
+    public GroovyRecipe parallelized(boolean isParallelized) {
+        this.parallelized = isParallelized;
+        return this;
+    }
+
+    public GroovyRecipe chance(float chance) {
+        if (lastComponent != null) {
+            if (lastComponent instanceof ComponentRequirement.ChancedRequirement chancedReq) {
+                chancedReq.setChance(chance);
+            } else {
+                GroovyLog.get().warn("Cannot set chance for not-chance-based Component: " + lastComponent.getClass());
+            }
+        }
+        return this;
+    }
+
+
+    public GroovyRecipe tag(String selectorTag) {
+        if (lastComponent != null) {
+            lastComponent.setTag(new ComponentSelectorTag(selectorTag));
+        }
+        return this;
+    }
+
+
+    public GroovyRecipe preViewNBT(NBTTagCompound nbt) {
+        if (lastComponent != null) {
+            if (lastComponent instanceof RequirementItem reqItem) {
+                reqItem.previewDisplayTag = nbt;
+            } else {
+                GroovyLog.get().warn("setPreViewNBT(IData nbt) only can be applied to `Item`!");
+            }
+        } else {
+            GroovyLog.get().warn("setPreViewNBT(IData nbt) only can be applied to `Item`!");
+        }
+        return this;
+    }
+
+
+    public GroovyRecipe nbtChecker(Closure<Boolean> checker) {
+        if (lastComponent != null) {
+            if (lastComponent instanceof RequirementItem reqItem) {
+                reqItem.setItemChecker((controller, stack) -> ClosureHelper.call(true, checker, controller, stack));
+            } else {
+                GroovyLog.get().warn("setNBTChecker(AdvancedItemNBTChecker checker) only can be applied to `Item`!");
+            }
+        } else {
+            GroovyLog.get().warn("setNBTChecker(AdvancedItemNBTChecker checker) only can be applied to `Item`!");
+        }
+        return this;
+    }
+
+
+    public GroovyRecipe itemModifier(Closure<ItemStack> modifier) {
+        if (lastComponent != null) {
+            if (lastComponent instanceof RequirementItem reqItem) {
+                reqItem.addItemModifier((controller, stack) -> ClosureHelper.call(stack, modifier, controller, stack));
+            } else {
+                GroovyLog.get().warn("addItemModifier(AdvancedItemModifier checker) only can be applied to `Item`!");
+            }
+        } else {
+            GroovyLog.get().warn("addItemModifier(AdvancedItemModifier checker) only can be applied to `Item`!");
+        }
+        return this;
+    }
+
+
+    public GroovyRecipe amount(int min, int max) {
+        if (lastComponent != null) {
+            if (lastComponent instanceof RequirementItem reqItem) {
+                if (min < max) {
+                    reqItem.minAmount = min;
+                    reqItem.maxAmount = max;
+                } else {
+                    GroovyLog.get().warn("`min` cannot larger than `max`!");
+                }
+            } else {
+                GroovyLog.get().warn("setMinMaxOutputAmount(int min, int max) only can be applied to `Item`!");
+            }
+        } else {
+            GroovyLog.get().warn("setMinMaxOutputAmount(int min, int max) only can be applied to `Item`!");
+        }
+        return this;
+    }
+
+    /**
+     * <p>为某个输入或输出设置特定触发时间。</p>
+     * <p>注意：如果设置了触发时间，则配方在其他时间不会触发任何消耗或产出动作。</p>
+     *
+     * @param tickTime 触发的配方时间，实际触发时间受到配方修改器影响
+     */
+
+    public GroovyRecipe triggerTime(int tickTime) {
+        if (lastComponent != null) {
+            lastComponent.setTriggerTime(tickTime);
+        }
+        return this;
+    }
+
+    /**
+     * 使触发时间可以被重复触发。
+     *
+     * @param repeatable true 为可重复，默认 false。
+     */
+
+    public GroovyRecipe triggerRepeatable(boolean repeatable) {
+        if (lastComponent != null) {
+            lastComponent.setTriggerRepeatable(repeatable);
+        }
+        return this;
+    }
+
+    /**
+     * <p>使一个物品/流体等需求忽略输出检测，对一些大量输出不同种类物品等需求非常有用。</p>
+     * <p>警告：如果忽略输出则有时可能会导致输出吞物品行为。</p>
+     *
+     * @param ignoreOutputCheck true 为忽略，默认为 false 不忽略。
+     */
+
+    public GroovyRecipe ignoreOutputCheck(boolean ignoreOutputCheck) {
+        if (lastComponent != null) {
+            lastComponent.setIgnoreOutputCheck(ignoreOutputCheck);
+        }
+        return this;
+    }
+
+
+    public GroovyRecipe recipeTooltip(String... tooltips) {
+        toolTipList.addAll(Arrays.asList(tooltips));
+        return this;
+    }
+
+
+    public GroovyRecipe smartInterfaceDataInput(String typeStr, float minValue, float maxValue) {
+        needAfterInitActions.add(() -> {
+            DynamicMachine machine = MachineRegistry.getRegistry().getMachine(machineName);
+            if (machine == null) {
+                GroovyLog.get().error("Could not find machine `" + machineName.toString() + "`!");
+                return;
+            }
+            SmartInterfaceType type = machine.getSmartInterfaceType(typeStr);
+            if (type == null) {
+                GroovyLog.get().error("SmartInterfaceType " + typeStr + " Not Found!");
+                return;
+            }
+            appendComponent(new RequirementInterfaceNumInput(type, minValue, maxValue));
+        });
+        return this;
+    }
+
+
+    public GroovyRecipe smartInterfaceDataInput(String typeStr, float value) {
+        return smartInterfaceDataInput(typeStr, value, value);
+    }
+
+    /**
+     * 设置此配方在工厂中同时运行的数量是否不超过指定数值。
+     */
+
+    public GroovyRecipe maxThreads(int maxThreads) {
+        this.maxThreads = maxThreads;
+        return this;
+    }
+
+    /**
+     * 设置此配方只能被指定的核心线程执行。
+     *
+     * @param name 线程名
+     */
+    public GroovyRecipe threadName(String name) {
+        this.threadName = name == null ? "" : name;
+        return this;
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // EventHandlers
+    //----------------------------------------------------------------------------------------------
+
+    public GroovyRecipe preCheckHandler(Closure<?> handler) {
+        addRecipeEventHandler(RecipeCheckEvent.class, event -> {
+            if (event.phase != Phase.START) return;
+            ClosureHelper.call(handler, event);
+        });
+        return this;
+    }
+
+
+    public GroovyRecipe postCheckHandler(Closure<?> handler) {
+        addRecipeEventHandler(RecipeCheckEvent.class, event -> {
+            if (event.phase != Phase.END) return;
+            ClosureHelper.call(handler, event);
+        });
+        return this;
+    }
+
+    public GroovyRecipe startHandler(Closure<?> handler) {
+        addRecipeEventHandler(RecipeStartEvent.class, IEventHandler.of(handler));
+        return this;
+    }
+
+    public GroovyRecipe preTickHandler(Closure<?> handler) {
+        addRecipeEventHandler(RecipeTickEvent.class, event -> {
+            if (event.phase != Phase.START) return;
+            ClosureHelper.call(handler, event);
+        });
+        return this;
+    }
+
+    public GroovyRecipe postTickHandler(Closure<?> handler) {
+        addRecipeEventHandler(RecipeTickEvent.class, event -> {
+            if (event.phase != Phase.END) return;
+            ClosureHelper.call(handler, event);
+        });
+        return this;
+    }
+
+    public GroovyRecipe failureHandler(Closure<?> handler) {
+        addRecipeEventHandler(RecipeFailureEvent.class, IEventHandler.of(handler));
+        return this;
+    }
+
+    public GroovyRecipe finishHandler(Closure<?> handler) {
+        addRecipeEventHandler(RecipeFinishEvent.class, IEventHandler.of(handler));
+        return this;
+    }
+
+    public GroovyRecipe factoryStartHandler(Closure<?> handler) {
+        addRecipeEventHandler(FactoryRecipeStartEvent.class, IEventHandler.of(handler));
+        return this;
+    }
+
+    public GroovyRecipe factoryPreTickHandler(Closure<?> handler) {
+        addRecipeEventHandler(FactoryRecipeTickEvent.class, event -> {
+            if (event.phase != Phase.START) {
+                return;
+            }
+            ClosureHelper.call(handler, event);
+        });
+        return this;
+    }
+
+    public GroovyRecipe factoryPostTickHandler(Closure<?> handler) {
+        addRecipeEventHandler(FactoryRecipeTickEvent.class, event -> {
+            if (event.phase != Phase.END) {
+                return;
+            }
+            ClosureHelper.call(handler, event);
+        });
+        return this;
+    }
+
+
+    public GroovyRecipe factoryFailureHandler(Closure<?> handler) {
+        return eventHandler(FactoryRecipeFailureEvent.class, handler);
+    }
+
+    public GroovyRecipe factoryFinishHandler(Closure<?> handler) {
+        return eventHandler(FactoryRecipeFinishEvent.class, handler);
+    }
+
+    public <H extends RecipeEvent> GroovyRecipe eventHandler(Closure<?> handler) {
+        if (handler.getParameterTypes().length > 0 && RecipeEvent.class.isAssignableFrom(handler.getParameterTypes()[0])) {
+            Class<H> eventClass = (Class<H>) handler.getParameterTypes()[0];
+            addRecipeEventHandler(eventClass, IEventHandler.of(handler));
+        } else {
+            GroovyLog.get().error("The parameter type must be explicitly declared when using `eventHandler({})`");
+        }
+        return this;
+    }
+
+    public <H extends RecipeEvent> GroovyRecipe eventHandler(Class<H> clazz, Closure<?> handler) {
+        addRecipeEventHandler(clazz, IEventHandler.of(handler));
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <H extends RecipeEvent> void addRecipeEventHandler(Class<H> hClass, IEventHandler<H> handler) {
+        recipeEventHandlers.putIfAbsent(hClass, new ArrayList<>());
+        recipeEventHandlers.get(hClass).add((IEventHandler<RecipeEvent>) handler);
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // General Input & Output
+    //----------------------------------------------------------------------------------------------
+
+    public GroovyRecipe input(IIngredient input) {
+        if (IngredientHelper.isItem(input) || input instanceof OreDictIngredient) {
+            itemInput(input);
+        } else if (input instanceof FluidStack liquidStack) {
+            fluidInput(liquidStack);
+        } else if (Mods.MEKANISM.isPresent() && input instanceof GasStack gasStack) {
+            gasInput(gasStack);
+        } else {
+            GroovyLog.get().error(String.format("Invalid input type %s(%s)! Ignored.", input, input.getClass()));
+        }
+        return this;
+    }
+
+    public GroovyRecipe input(IIngredient... inputs) {
+        for (IIngredient input : inputs) {
+            input(input);
+        }
+        return this;
+    }
+
+    public GroovyRecipe input(Iterable<IIngredient> inputs) {
+        for (IIngredient input : inputs) {
+            input(input);
+        }
+        return this;
+    }
+
+    public GroovyRecipe output(IIngredient output) {
+        if (IngredientHelper.isItem(output) || output instanceof OreDictIngredient) {
+            itemOutput(output);
+        } else if (output instanceof FluidStack liquidStack) {
+            fluidOutput(liquidStack);
+        } else if (Mods.MEKANISM.isPresent() && output instanceof GasStack gasStack) {
+            gasOutput(gasStack);
+        } else {
+            GroovyLog.get().error(String.format("Invalid output type %s(%s)! Ignored.", output, output.getClass()));
+        }
+        return this;
+    }
+
+    public GroovyRecipe output(IIngredient... outputs) {
+        for (IIngredient output : outputs) {
+            output(output);
+        }
+        return this;
+    }
+
+    public GroovyRecipe output(Iterable<IIngredient> outputs) {
+        for (IIngredient output : outputs) {
+            output(output);
+        }
+        return this;
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Energy input & output
+    //----------------------------------------------------------------------------------------------
+
+    public GroovyRecipe energyInput(long perTick) {
+        requireEnergy(IOType.INPUT, perTick);
+        return this;
+    }
+
+
+    public GroovyRecipe energyOutput(long perTick) {
+        requireEnergy(IOType.OUTPUT, perTick);
+        return this;
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // FLUID input & output
+    //----------------------------------------------------------------------------------------------
+
+    public GroovyRecipe fluidInput(FluidStack fluid, boolean perTick) {
+        requireFluid(IOType.INPUT, fluid, perTick);
+        return this;
+    }
+
+    public GroovyRecipe fluidInput(FluidStack fluid) {
+        return fluidInput(fluid, false);
+    }
+
+    public GroovyRecipe fluidInput(FluidStack... fluids) {
+        for (FluidStack fluid : fluids) {
+            fluidInput(fluid);
+        }
+        return this;
+    }
+
+    public GroovyRecipe fluidInput(Iterable<FluidStack> fluids, boolean perTick) {
+        for (FluidStack fluid : fluids) {
+            fluidInput(fluid, perTick);
+        }
+        return this;
+    }
+
+    public GroovyRecipe fluidInput(Iterable<FluidStack> fluids) {
+        return fluidInput(fluids, false);
+    }
+
+    public GroovyRecipe fluidOutput(FluidStack fluid) {
+        return fluidOutput(fluid, false);
+    }
+
+    public GroovyRecipe fluidOutput(FluidStack fluid, boolean perTick) {
+        requireFluid(IOType.OUTPUT, fluid, perTick);
+        return this;
+    }
+
+
+    public GroovyRecipe fluidOutputs(FluidStack... fluids) {
+        for (FluidStack fluid : fluids) {
+            fluidOutput(fluid);
+        }
+        return this;
+    }
+
+    public GroovyRecipe fluidOutputs(Iterable<FluidStack> fluids, boolean perTick) {
+        for (FluidStack fluid : fluids) {
+            fluidOutput(fluid, perTick);
+        }
+        return this;
+    }
+
+    public GroovyRecipe fluidOutputs(Iterable<FluidStack> fluids) {
+        return fluidOutputs(fluids, false);
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // GAS input & output
+    //----------------------------------------------------------------------------------------------
+
+    @Optional.Method(modid = "mekanism")
+    public GroovyRecipe gasInput(GasStack gasStack) {
+        requireGas(IOType.INPUT, gasStack);
+        return this;
+    }
+
+
+    @Optional.Method(modid = "mekanism")
+    public GroovyRecipe gasOutput(GasStack gasStack) {
+        requireGas(IOType.OUTPUT, gasStack);
+        return this;
+    }
+
+
+    @Optional.Method(modid = "mekanism")
+    public GroovyRecipe gasInput(GasStack... gasStacks) {
+        for (final GasStack gasStack : gasStacks) {
+            requireGas(IOType.INPUT, gasStack);
+        }
+        return this;
+    }
+
+    @Optional.Method(modid = "mekanism")
+    public GroovyRecipe gasInput(Iterable<GasStack> gasStacks) {
+        for (final GasStack gasStack : gasStacks) {
+            requireGas(IOType.INPUT, gasStack);
+        }
+        return this;
+    }
+
+
+    @Optional.Method(modid = "mekanism")
+    public GroovyRecipe gasOutput(GasStack... gasStacks) {
+        for (final GasStack gasStack : gasStacks) {
+            requireGas(IOType.OUTPUT, gasStack);
+        }
+        return this;
+    }
+
+    @Optional.Method(modid = "mekanism")
+    public GroovyRecipe gasOutput(Iterable<GasStack> gasStacks) {
+        for (final GasStack gasStack : gasStacks) {
+            requireGas(IOType.OUTPUT, gasStack);
+        }
+        return this;
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // ITEM input
+    //----------------------------------------------------------------------------------------------
+
+    public GroovyRecipe itemInput(IIngredient input) {
+        if (IngredientHelper.isItem(input)) {
+            requireFuel(IOType.INPUT, IngredientHelper.toItemStack(input));
+        } else if (input instanceof OreDictIngredient oreDictIngredient) {
+            requireFuel(IOType.INPUT, oreDictIngredient.getOreDict(), oreDictIngredient.getAmount());
+        } else {
+            GroovyLog.get().error(String.format("Invalid input type %s(%s)! Ignored.", input, input.getClass()));
+        }
+
+        return this;
+    }
+
+    public GroovyRecipe itemInputs(IIngredient... inputs) {
+        for (IIngredient input : inputs) {
+            itemInput(input);
+        }
+        return this;
+    }
+
+    public GroovyRecipe itemInputs(Iterable<IIngredient> inputs) {
+        for (IIngredient input : inputs) {
+            itemInput(input);
+        }
+        return this;
+    }
+
+    public GroovyRecipe fuelBurnTime(int requiredTotalBurnTime) {
+        requireFuel(requiredTotalBurnTime);
+        return this;
+    }
+
+    // TODO
+    public GroovyRecipe addIngredientArrayInput(IngredientArrayPrimer ingredientArrayPrimer) {
+        appendComponent(new RequirementIngredientArray(ingredientArrayPrimer.getIngredientStackList()));
+        return this;
+    }
+
+    /**
+     * <p>随机选择给定的一组物品中的其中一个输出。</p>
+     * <p>虽然都使用 IngredientArrayPrimer 作为参数，但是输出的工作机制要<strong>稍有不同</strong>。</p>
+     * <p>每个 Ingredient 的 chance 代表整个物品列表的随机选择权重，权重越高，输出概率越大。</p>
+     * <p>同样，setMinMaxAmount() 也能够起作用。</p>
+     */
+    // TODO
+    public GroovyRecipe addRandomItemOutput(IngredientArrayPrimer ingredientArrayPrimer) {
+        appendComponent(new RequirementIngredientArray(ingredientArrayPrimer.getIngredientStackList(), IOType.OUTPUT));
+        return this;
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // ITEM output
+    //----------------------------------------------------------------------------------------------
+
+    public GroovyRecipe itemOutput(IIngredient output) {
+        if (IngredientHelper.isItem(output)) {
+            requireFuel(IOType.OUTPUT, IngredientHelper.toItemStack(output));
+        } else if (output instanceof OreDictIngredient oreDictIngredient) {
+            requireFuel(IOType.OUTPUT, oreDictIngredient.getOreDict(), oreDictIngredient.getAmount());
+        } else {
+            GroovyLog.get().error(String.format("Invalid output type %s(%s)! Ignored.", output, output.getClass()));
+        }
+
+        return this;
+    }
+
+    public GroovyRecipe itemOutputs(IIngredient... inputs) {
+        for (IIngredient input : inputs) {
+            itemOutput(input);
+        }
+        return this;
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Catalyst
+    //----------------------------------------------------------------------------------------------
+
+    public GroovyRecipe catalyst(IIngredient input, Iterable<String> tooltips, Iterable<RecipeModifier> modifiers) {
+        if (IngredientHelper.isItem(input)) {
+            requireCatalyst(IngredientHelper.toItemStack(input), tooltips, modifiers);
+        } else if (input instanceof OreDictIngredient oreDictIngredient) {
+            requireCatalyst(oreDictIngredient.getOreDict(), oreDictIngredient.getAmount(), tooltips, modifiers);
+        } else {
+            GroovyLog.get().error(String.format("Invalid input type %s(%s)! Ignored.", input, input.getClass()));
+        }
+
+        return this;
+    }
+
+
+    // TODO
+    public GroovyRecipe addCatalystInput(IngredientArrayPrimer input, Iterable<String> tooltips, Iterable<RecipeModifier> modifiers) {
+        requireCatalyst(input, tooltips, modifiers);
+        return this;
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // Internals
+    //----------------------------------------------------------------------------------------------
+    private void requireEnergy(IOType ioType, long perTick) {
+        appendComponent(new RequirementEnergy(ioType, perTick));
+    }
+
+    private void requireFluid(IOType ioType, FluidStack stack, boolean isPerTick) {
+        if (stack == null) {
+            GroovyLog.get().error("FluidStack not found/unknown fluid");
+            return;
+        }
+
+        if (isPerTick) {
+            appendComponent(new RequirementFluidPerTick(ioType, stack));
+        } else {
+            appendComponent(new RequirementFluid(ioType, stack));
+        }
+    }
+
+    @Optional.Method(modid = "mekanism")
+    private void requireGas(IOType ioType, GasStack gasStack) {
+        appendComponent(RequirementFluid.createMekanismGasRequirement(RequirementTypesMM.REQUIREMENT_GAS, ioType, gasStack));
+    }
+
+    private void requireFuel(int requiredTotalBurnTime) {
+        appendComponent(new RequirementItem(IOType.INPUT, requiredTotalBurnTime));
+    }
+
+    private void requireFuel(IOType ioType, ItemStack stack) {
+        if (stack.isEmpty()) {
+            GroovyLog.get().error("ItemStack not found/unknown item: " + stack);
+            return;
+        }
+        RequirementItem ri = new RequirementItem(ioType, stack);
+        if (stack.hasTagCompound()) {
+            ri.tag = stack.getTagCompound();
+            ri.previewDisplayTag = stack.getTagCompound();
+        }
+        appendComponent(ri);
+    }
+
+    private void requireFuel(IOType ioType, String oreDictName, int amount) {
+        appendComponent(new RequirementItem(ioType, oreDictName, amount));
+    }
+
+    private void requireCatalyst(String oreDictName, int amount, Iterable<String> tooltips, Iterable<RecipeModifier> modifiers) {
+        RequirementCatalyst catalyst = new RequirementCatalyst(oreDictName, amount);
+        for (String tooltip : tooltips) {
+            catalyst.addTooltip(tooltip);
+        }
+        for (RecipeModifier modifier : modifiers) {
+            if (modifier != null) {
+                catalyst.addModifier(modifier);
+            }
+        }
+        appendComponent(catalyst);
+    }
+
+    private void requireCatalyst(ItemStack stack, Iterable<String> tooltips, Iterable<RecipeModifier> modifiers) {
+        if (stack.isEmpty()) {
+            GroovyLog.get().error("ItemStack not found/unknown item: " + stack);
+            return;
+        }
+        RequirementCatalyst catalyst = new RequirementCatalyst(stack);
+        for (String tooltip : tooltips) {
+            catalyst.addTooltip(tooltip);
+        }
+        for (RecipeModifier modifier : modifiers) {
+            if (modifier != null) {
+                catalyst.addModifier(modifier);
+            }
+        }
+        appendComponent(catalyst);
+    }
+
+    private void requireCatalyst(IngredientArrayPrimer ingredientArrayPrimer, Iterable<String> tooltips, Iterable<RecipeModifier> modifiers) {
+        RequirementCatalyst catalyst = new RequirementCatalyst(ingredientArrayPrimer.getIngredientStackList());
+        for (String tooltip : tooltips) {
+            catalyst.addTooltip(tooltip);
+        }
+        for (RecipeModifier modifier : modifiers) {
+            if (modifier != null) {
+                catalyst.addModifier(modifier);
+            }
+        }
+        appendComponent(catalyst);
+    }
+
+    public void appendComponent(ComponentRequirement<?, ?> component) {
+        this.components.add(component);
+        this.lastComponent = component;
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // build
+    //----------------------------------------------------------------------------------------------
+
+    private boolean validate() {
+        GroovyLog.Msg msg = GroovyLog.msg("Error adding {} recipe", this.name).error();
+        if (this.name == null) this.name = RecipeName.generate();
+        if (this.tickTime <= 0) this.tickTime = 100;
+
+        return !msg.postIfNotEmpty();
+    }
+
+    public void register() {
+        if (validate()) {
+            RecipeRegistry.getRegistry().registerRecipeEarly(this);
+        }
+    }
+
+    //----------------------------------------------------------------------------------------------
+    // lingering stats
+    //----------------------------------------------------------------------------------------------
+
+    @Override
+    public String getFilePath() {
+        return "";
+    }
+
+    @Override
+    public ResourceLocation getRecipeRegistryName() {
+        return new ResourceLocation(ModularMachinery.MODID, this.name);
+    }
+
+    @Override
+    public ResourceLocation getAssociatedMachineName() {
+        return machineName;
+    }
+
+    @Override
+    public ResourceLocation getParentMachineName() {
+        return machineName;
+    }
+
+    @Override
+    public int getTotalProcessingTickTime() {
+        return tickTime;
+    }
+
+    @Override
+    public int getPriority() {
+        return priority;
+    }
+
+    @Override
+    public boolean voidPerTickFailure() {
+        return doesVoidPerTick;
+    }
+
+    @Override
+    public List<ComponentRequirement<?, ?>> getComponents() {
+        return components;
+    }
+
+    @Override
+    public Map<Class<?>, List<IEventHandler<RecipeEvent>>> getRecipeEventHandlers() {
+        return recipeEventHandlers;
+    }
+
+    @Override
+    public List<String> getTooltipList() {
+        return toolTipList;
+    }
+
+    @Override
+    public boolean isParallelized() {
+        return parallelized;
+    }
+
+    @Override
+    public int getMaxThreads() {
+        return maxThreads;
+    }
+
+    @Override
+    public String getThreadName() {
+        return threadName;
+    }
+
+    @Override
+    public void loadNeedAfterInitActions() {
+        for (Action needAfterInitAction : needAfterInitActions) {
+            needAfterInitAction.doAction();
+        }
+    }
+}
+

--- a/src/main/java/github/kasuminova/mmce/common/integration/groovyscript/Plugin.java
+++ b/src/main/java/github/kasuminova/mmce/common/integration/groovyscript/Plugin.java
@@ -1,0 +1,217 @@
+package github.kasuminova.mmce.common.integration.groovyscript;
+
+import com.cleanroommc.groovyscript.api.GroovyPlugin;
+import com.cleanroommc.groovyscript.api.INamed;
+import com.cleanroommc.groovyscript.compat.mods.GroovyContainer;
+import com.cleanroommc.groovyscript.compat.mods.ModPropertyContainer;
+import github.kasuminova.mmce.client.model.DynamicMachineModelRegistry;
+import github.kasuminova.mmce.client.resource.GeoModelExternalLoader;
+import github.kasuminova.mmce.common.concurrent.RecipeCraftingContextPool;
+import github.kasuminova.mmce.common.upgrade.registry.RegistryUpgrade;
+import github.kasuminova.mmce.common.util.concurrent.Action;
+import hellfirepvp.modularmachinery.ModularMachinery;
+import hellfirepvp.modularmachinery.client.ClientProxy;
+import hellfirepvp.modularmachinery.common.base.Mods;
+import hellfirepvp.modularmachinery.common.crafting.RecipeRegistry;
+import hellfirepvp.modularmachinery.common.crafting.adapter.RecipeAdapter;
+import hellfirepvp.modularmachinery.common.integration.ModIntegrationJEI;
+import hellfirepvp.modularmachinery.common.integration.crafttweaker.MachineBuilder;
+import hellfirepvp.modularmachinery.common.integration.crafttweaker.MachineModifier;
+import hellfirepvp.modularmachinery.common.integration.crafttweaker.event.MMEvents;
+import hellfirepvp.modularmachinery.common.lib.RegistriesMM;
+import hellfirepvp.modularmachinery.common.machine.DynamicMachine;
+import hellfirepvp.modularmachinery.common.machine.MachineRegistry;
+import hellfirepvp.modularmachinery.common.machine.factory.FactoryRecipeThread;
+import hellfirepvp.modularmachinery.common.util.BlockArrayCache;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import youyihj.zenutils.api.reload.ScriptReloadEvent;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public class Plugin implements GroovyPlugin {
+
+    private static GroovyContainer<?> container;
+
+    public static GroovyContainer<?> getContainer() {
+        return container;
+    }
+
+    @Override
+    public @NotNull String getModId() {
+        return ModularMachinery.MODID;
+    }
+
+    @Override
+    public @NotNull String getContainerName() {
+        return ModularMachinery.NAME;
+    }
+
+    @Override
+    public @Nullable ModPropertyContainer createModPropertyContainer() {
+        return new Container();
+    }
+
+    @Override
+    public void onCompatLoaded(GroovyContainer<?> container) {
+        Plugin.container = container;
+    }
+
+    private static void onReload() {
+        MachineBuilder.WAIT_FOR_LOAD.clear();
+
+        RegistryUpgrade.clearAll();
+        RecipeRegistry.getRegistry().clearAllRecipes();
+        // Reset RecipeAdapterIncId
+        RegistriesMM.ADAPTER_REGISTRY.getValuesCollection().forEach(RecipeAdapter::resetIncId);
+
+        if (FMLCommonHandler.instance().getSide().isClient() && Mods.GECKOLIB.isPresent()) {
+            DynamicMachineModelRegistry.INSTANCE.onReload();
+        }
+
+        for (DynamicMachine loadedMachine : MachineRegistry.getLoadedMachines()) {
+            loadedMachine.getMachineEventHandlers().clear();
+            loadedMachine.getSmartInterfaceTypes().clear();
+            loadedMachine.getCoreThreadPreset().clear();
+            loadedMachine.getModifiers().clear();
+            loadedMachine.getMultiBlockModifiers().clear();
+        }
+        // Reload JSON Machine
+        MachineRegistry.preloadMachines();
+        // Reload All Machine
+        MachineRegistry.reloadMachine(MachineRegistry.loadMachines(null));
+    }
+
+    private static void afterScriptRun() {
+        MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
+        boolean isServer = server != null && server.isDedicatedServer();
+
+        MachineRegistry.reloadMachine(MachineBuilder.WAIT_FOR_LOAD);
+
+        if (FMLCommonHandler.instance().getSide().isClient() && Mods.GECKOLIB.isPresent()) {
+            ClientProxy.clientScheduler.addRunnable(GeoModelExternalLoader.INSTANCE::onReload, 0);
+        }
+
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> BlockArrayCache.buildCache(MachineRegistry.getLoadedMachines()));
+
+        MachineModifier.loadAll();
+        MMEvents.registryAll();
+
+        RecipeCraftingContextPool.onReload();
+        RecipeRegistry.getRegistry().loadRecipeRegistry(null, true);
+        // TODO
+        /*for (Action action : FactoryRecipeThread.WAIT_FOR_ADD) {
+            action.doAction();
+        }
+        FactoryRecipeThread.WAIT_FOR_ADD.clear();*/
+
+        if (!isServer) {
+            ModIntegrationJEI.reloadRecipeWrappers();
+        }
+
+        future.join();
+
+        // Flush the context to preview the changed structure.
+        if (!isServer) {
+            ModIntegrationJEI.reloadPreviewWrappers();
+        }
+    }
+
+    private static class Container extends ModPropertyContainer {
+
+        private final GroovyMachine dummy = new DummyMachine();
+        private final Map<ResourceLocation, GroovyMachine> machines = new Object2ObjectOpenHashMap<>();
+        private final Map<String, GroovyMachine> properties = new Object2ObjectOpenHashMap<>();
+
+        public GroovyMachine machine(ResourceLocation rl) {
+            GroovyMachine machine = this.machines.get(rl);
+            if (machine == null) {
+                DynamicMachine dynamicMachine = MachineRegistry.getRegistry().getMachine(rl);
+                if (dynamicMachine != null) {
+                    machine = new GroovyMachine(rl);
+                    this.machines.put(rl, machine);
+                    this.properties.put(rl.getPath(), machine);
+                }
+            }
+            return machine;
+        }
+
+        public GroovyMachine machine(String mod, String name) {
+            return machine(new ResourceLocation(mod, name));
+        }
+
+        public GroovyMachine machine(String name) {
+            String mod;
+            int i = name.indexOf(":");
+            if (i > 0) {
+                mod = name.substring(0, i);
+                name = name.substring(i + 1);
+            } else if (i == 0) {
+                mod = ModularMachinery.MODID;
+                name = name.substring(1);
+            } else {
+                mod = ModularMachinery.MODID;
+            }
+            return machine(new ResourceLocation(mod, name));
+        }
+
+        @Override
+        public @Nullable Object getProperty(String name) {
+            return machine(new ResourceLocation(ModularMachinery.MODID, name));
+        }
+
+        @Override
+        public Map<String, Object> getProperties() {
+            for (DynamicMachine machine : MachineRegistry.getLoadedMachines()) {
+                if (!this.machines.containsKey(machine.getRegistryName())) {
+                    GroovyMachine groovyMachine = new GroovyMachine(machine.getRegistryName());
+                    this.machines.put(machine.getRegistryName(), groovyMachine);
+                    this.properties.put(machine.getRegistryName().getPath(), groovyMachine);
+                }
+            }
+            return Collections.unmodifiableMap(this.properties);
+        }
+
+        public Object getAt(String name) {
+            return machine(name);
+        }
+
+        @Override
+        public Collection<INamed> getRegistries() {
+            return Collections.singleton(this.dummy);
+        }
+    }
+
+    private static class DummyMachine extends GroovyMachine {
+
+        public DummyMachine() {
+            super(new ResourceLocation(ModularMachinery.MODID, "machine_name"));
+        }
+
+        @Override
+        public void onReload() {
+            Plugin.onReload();
+        }
+
+        @Override
+        public void afterScriptLoad() {
+            Plugin.afterScriptRun();
+        }
+
+        @Override
+        public GroovyRecipe recipeBuilder(String name) {
+            throw new UnsupportedOperationException();
+        }
+    }
+ }

--- a/src/main/java/hellfirepvp/modularmachinery/ModularMachinery.java
+++ b/src/main/java/hellfirepvp/modularmachinery/ModularMachinery.java
@@ -42,7 +42,8 @@ import org.apache.logging.log4j.Logger;
  */
 @Mod(modid = ModularMachinery.MODID, name = ModularMachinery.NAME, version = ModularMachinery.VERSION,
         dependencies = "required-after:forge@[14.21.0.2371,);" +
-                "required-after:crafttweaker@[4.0.4,);" +
+                "after:crafttweaker@[4.0.4,);" +
+                //"after:groovyscript@[1.0.0,);" + // TODO wait for grs 1.0.1
                 "after:zenutils@[1.12.8,);" +
                 "after:jei@[4.13.1.222,);" +
                 "after:gregtech@[2.7.4-beta,);" +

--- a/src/main/java/hellfirepvp/modularmachinery/common/base/Mods.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/base/Mods.java
@@ -18,6 +18,7 @@ import net.minecraftforge.fml.common.Loader;
  * Date: 02.03.2019 / 17:42
  */
 public enum Mods {
+    GROOVYSCRIPT("groovyscript"),
     CRAFTTWEAKER("crafttweaker"),
     JEI("jei"),
     GREGTECH("gregtech"),

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/MachineRecipe.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/MachineRecipe.java
@@ -11,7 +11,7 @@ package hellfirepvp.modularmachinery.common.crafting;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.gson.*;
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.ModularMachinery;
 import hellfirepvp.modularmachinery.common.crafting.command.RecipeCommandContainer;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/PreparedRecipe.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/PreparedRecipe.java
@@ -8,7 +8,7 @@
 
 package hellfirepvp.modularmachinery.common.crafting;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.common.crafting.helper.ComponentRequirement;
 import net.minecraft.util.ResourceLocation;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/RecipeRegistry.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/RecipeRegistry.java
@@ -16,6 +16,7 @@ import hellfirepvp.modularmachinery.common.crafting.adapter.RecipeAdapterAccesso
 import hellfirepvp.modularmachinery.common.data.DataLoadProfiler;
 import hellfirepvp.modularmachinery.common.integration.crafttweaker.RecipeAdapterBuilder;
 import hellfirepvp.modularmachinery.common.machine.DynamicMachine;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Tuple;
@@ -37,11 +38,11 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RecipeRegistry {
 
     private static final RecipeRegistry INSTANCE = new RecipeRegistry();
-    private static final Map<ResourceLocation, TreeMap<Integer, TreeSet<MachineRecipe>>> REGISTRY_RECIPE_BY_MACHINE = new HashMap<>();
-    private static final Map<ResourceLocation, MachineRecipe> RECIPE_REGISTRY = new HashMap<>();
+    private static final Map<ResourceLocation, TreeMap<Integer, TreeSet<MachineRecipe>>> REGISTRY_RECIPE_BY_MACHINE = new Object2ObjectOpenHashMap<>();
+    private static final Map<ResourceLocation, MachineRecipe> RECIPE_REGISTRY = new Object2ObjectOpenHashMap<>();
 
-    private final List<PreparedRecipe> earlyRecipes = new LinkedList<>();
-    private final List<RecipeAdapterBuilder> earlyRecipeAdapters = new LinkedList<>();
+    private final List<PreparedRecipe> earlyRecipes = new ArrayList<>();
+    private final List<RecipeAdapterBuilder> earlyRecipeAdapters = new ArrayList<>();
 
     private RecipeRegistry() {
     }

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/AdapterMinecraftFurnace.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/AdapterMinecraftFurnace.java
@@ -8,8 +8,8 @@
 
 package hellfirepvp.modularmachinery.common.crafting.adapter;
 
-import crafttweaker.util.IEventHandler;
 import github.kasuminova.mmce.common.event.Phase;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeCheckEvent;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/DynamicMachineRecipeAdapter.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/DynamicMachineRecipeAdapter.java
@@ -8,7 +8,7 @@
 
 package hellfirepvp.modularmachinery.common.crafting.adapter;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.ModularMachinery;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/RecipeAdapter.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/RecipeAdapter.java
@@ -8,7 +8,7 @@
 
 package hellfirepvp.modularmachinery.common.crafting.adapter;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;
 import hellfirepvp.modularmachinery.common.crafting.helper.ComponentRequirement;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/RecipeAdapterAccessor.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/RecipeAdapterAccessor.java
@@ -10,7 +10,7 @@ package hellfirepvp.modularmachinery.common.crafting.adapter;
 
 import com.google.common.collect.ImmutableList;
 import com.google.gson.*;
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.ModularMachinery;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/RecipeAdapterRegistry.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/RecipeAdapterRegistry.java
@@ -8,7 +8,7 @@
 
 package hellfirepvp.modularmachinery.common.crafting.adapter;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;
 import hellfirepvp.modularmachinery.common.crafting.helper.ComponentRequirement;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/ic2/AdapterIC2Compressor.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/ic2/AdapterIC2Compressor.java
@@ -1,15 +1,10 @@
 package hellfirepvp.modularmachinery.common.crafting.adapter.ic2;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;
 import hellfirepvp.modularmachinery.common.crafting.helper.ComponentRequirement;
-import hellfirepvp.modularmachinery.common.crafting.requirement.RequirementEnergy;
-import hellfirepvp.modularmachinery.common.crafting.requirement.RequirementItem;
-import hellfirepvp.modularmachinery.common.lib.RequirementTypesMM;
-import hellfirepvp.modularmachinery.common.machine.IOType;
 import hellfirepvp.modularmachinery.common.modifier.RecipeModifier;
-import hellfirepvp.modularmachinery.common.util.ItemUtils;
 import ic2.api.recipe.IRecipeInput;
 import ic2.api.recipe.Recipes;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/ic2/AdapterIC2Macerator.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/ic2/AdapterIC2Macerator.java
@@ -1,6 +1,6 @@
 package hellfirepvp.modularmachinery.common.crafting.adapter.ic2;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;
 import hellfirepvp.modularmachinery.common.crafting.helper.ComponentRequirement;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/nco/AdapterNCOAlloyFurnace.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/nco/AdapterNCOAlloyFurnace.java
@@ -1,6 +1,6 @@
 package hellfirepvp.modularmachinery.common.crafting.adapter.nco;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import github.kasuminova.mmce.common.itemtype.ChancedIngredientStack;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/nco/AdapterNCOChemicalReactor.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/nco/AdapterNCOChemicalReactor.java
@@ -1,6 +1,6 @@
 package hellfirepvp.modularmachinery.common.crafting.adapter.nco;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;
 import hellfirepvp.modularmachinery.common.crafting.helper.ComponentRequirement;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/nco/AdapterNCOInfuser.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/nco/AdapterNCOInfuser.java
@@ -1,6 +1,6 @@
 package hellfirepvp.modularmachinery.common.crafting.adapter.nco;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import github.kasuminova.mmce.common.itemtype.ChancedIngredientStack;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/nco/AdapterNCOMelter.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/nco/AdapterNCOMelter.java
@@ -1,6 +1,6 @@
 package hellfirepvp.modularmachinery.common.crafting.adapter.nco;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import github.kasuminova.mmce.common.itemtype.ChancedIngredientStack;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/tc6/AdapterTC6InfusionMatrix.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/tc6/AdapterTC6InfusionMatrix.java
@@ -1,6 +1,6 @@
 package hellfirepvp.modularmachinery.common.crafting.adapter.tc6;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import github.kasuminova.mmce.common.itemtype.ChancedIngredientStack;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;
@@ -14,13 +14,9 @@ import hellfirepvp.modularmachinery.common.modifier.RecipeModifier;
 import hellfirepvp.modularmachinery.common.util.ItemUtils;
 import kport.modularmagic.common.crafting.requirement.RequirementAspect;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.util.ResourceLocation;
 import thaumcraft.api.ThaumcraftApi;
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.api.crafting.IThaumcraftRecipe;
 import thaumcraft.api.crafting.InfusionRecipe;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/tconstruct/AdapterSmelteryAlloyRecipe.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/tconstruct/AdapterSmelteryAlloyRecipe.java
@@ -1,6 +1,6 @@
 package hellfirepvp.modularmachinery.common.crafting.adapter.tconstruct;
 
-import crafttweaker.util.IEventHandler;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import hellfirepvp.modularmachinery.common.crafting.MachineRecipe;
 import hellfirepvp.modularmachinery.common.crafting.adapter.RecipeAdapter;

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/tconstruct/AdapterSmelteryMeltingRecipe.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/adapter/tconstruct/AdapterSmelteryMeltingRecipe.java
@@ -1,7 +1,7 @@
 package hellfirepvp.modularmachinery.common.crafting.adapter.tconstruct;
 
-import crafttweaker.util.IEventHandler;
 import github.kasuminova.mmce.common.event.Phase;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.RecipeCheckEvent;
 import github.kasuminova.mmce.common.event.recipe.RecipeEvent;
 import github.kasuminova.mmce.common.itemtype.ChancedIngredientStack;

--- a/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/MachineBuilder.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/MachineBuilder.java
@@ -346,7 +346,7 @@ public class MachineBuilder {
      */
     @ZenMethod
     public MachineBuilder addStructureFormedHandler(IEventHandler<MachineStructureFormedEvent> function) {
-        machine.addMachineEventHandler(MachineStructureFormedEvent.class, function);
+        machine.addMachineEventHandler(MachineStructureFormedEvent.class, function::handle);
         return this;
     }
 
@@ -355,7 +355,7 @@ public class MachineBuilder {
      */
     @ZenMethod
     public MachineBuilder addStructureUpdateHandler(IEventHandler<MachineStructureUpdateEvent> function) {
-        machine.addMachineEventHandler(MachineStructureUpdateEvent.class, function);
+        machine.addMachineEventHandler(MachineStructureUpdateEvent.class, function::handle);
         return this;
     }
 
@@ -364,7 +364,7 @@ public class MachineBuilder {
      */
     @ZenMethod
     public MachineBuilder addTickHandler(IEventHandler<MachineTickEvent> function) {
-        machine.addMachineEventHandler(MachineTickEvent.class, function);
+        machine.addMachineEventHandler(MachineTickEvent.class, function::handle);
         return this;
     }
 
@@ -376,7 +376,7 @@ public class MachineBuilder {
         if (FMLCommonHandler.instance().getSide().isServer()) {
             return this;
         }
-        machine.addMachineEventHandler(ControllerGUIRenderEvent.class, function);
+        machine.addMachineEventHandler(ControllerGUIRenderEvent.class, function::handle);
         return this;
     }
 
@@ -389,7 +389,7 @@ public class MachineBuilder {
         if (FMLCommonHandler.instance().getSide().isServer()) {
             return this;
         }
-        machine.addMachineEventHandler(ControllerModelAnimationEvent.class, function);
+        machine.addMachineEventHandler(ControllerModelAnimationEvent.class, function::handle);
         return this;
     }
 
@@ -402,7 +402,7 @@ public class MachineBuilder {
         if (FMLCommonHandler.instance().getSide().isServer()) {
             return this;
         }
-        machine.addMachineEventHandler(ControllerModelGetEvent.class, function);
+        machine.addMachineEventHandler(ControllerModelGetEvent.class, function::handle);
         return this;
     }
 
@@ -411,7 +411,7 @@ public class MachineBuilder {
      */
     @ZenMethod
     public MachineBuilder addSmartInterfaceUpdateHandler(IEventHandler<SmartInterfaceUpdateEvent> function) {
-        machine.addMachineEventHandler(SmartInterfaceUpdateEvent.class, function);
+        machine.addMachineEventHandler(SmartInterfaceUpdateEvent.class, function::handle);
         return this;
     }
 

--- a/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/RecipePrimer.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/RecipePrimer.java
@@ -17,8 +17,8 @@ import crafttweaker.api.item.IngredientStack;
 import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.api.oredict.IOreDictEntry;
-import crafttweaker.util.IEventHandler;
 import github.kasuminova.mmce.common.event.Phase;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.recipe.*;
 import github.kasuminova.mmce.common.util.concurrent.Action;
 import hellfirepvp.modularmachinery.common.base.Mods;
@@ -273,7 +273,7 @@ public class RecipePrimer implements PreparedRecipe {
     //----------------------------------------------------------------------------------------------
 
     @ZenMethod
-    public RecipePrimer addPreCheckHandler(IEventHandler<RecipeCheckEvent> handler) {
+    public RecipePrimer addPreCheckHandler(crafttweaker.util.IEventHandler<RecipeCheckEvent> handler) {
         addRecipeEventHandler(RecipeCheckEvent.class, event -> {
             if (event.phase != Phase.START) return;
             handler.handle(event);
@@ -282,7 +282,7 @@ public class RecipePrimer implements PreparedRecipe {
     }
 
     @ZenMethod
-    public RecipePrimer addPostCheckHandler(IEventHandler<RecipeCheckEvent> handler) {
+    public RecipePrimer addPostCheckHandler(crafttweaker.util.IEventHandler<RecipeCheckEvent> handler) {
         addRecipeEventHandler(RecipeCheckEvent.class, event -> {
             if (event.phase != Phase.END) return;
             handler.handle(event);
@@ -292,20 +292,20 @@ public class RecipePrimer implements PreparedRecipe {
 
     @ZenMethod
     @Deprecated
-    public RecipePrimer addCheckHandler(IEventHandler<RecipeCheckEvent> handler) {
+    public RecipePrimer addCheckHandler(crafttweaker.util.IEventHandler<RecipeCheckEvent> handler) {
         CraftTweakerAPI.logWarning("[ModularMachinery] Deprecated method addCheckHandler()! Consider using addPostCheckHandler()");
-        addRecipeEventHandler(RecipeCheckEvent.class, handler);
+        addRecipeEventHandler(RecipeCheckEvent.class, handler::handle);
         return this;
     }
 
     @ZenMethod
-    public RecipePrimer addStartHandler(IEventHandler<RecipeStartEvent> handler) {
-        addRecipeEventHandler(RecipeStartEvent.class, handler);
+    public RecipePrimer addStartHandler(crafttweaker.util.IEventHandler<RecipeStartEvent> handler) {
+        addRecipeEventHandler(RecipeStartEvent.class, handler::handle);
         return this;
     }
 
     @ZenMethod
-    public RecipePrimer addPreTickHandler(IEventHandler<RecipeTickEvent> handler) {
+    public RecipePrimer addPreTickHandler(crafttweaker.util.IEventHandler<RecipeTickEvent> handler) {
         addRecipeEventHandler(RecipeTickEvent.class, event -> {
             if (event.phase != Phase.START) return;
             handler.handle(event);
@@ -314,7 +314,7 @@ public class RecipePrimer implements PreparedRecipe {
     }
 
     @ZenMethod
-    public RecipePrimer addPostTickHandler(IEventHandler<RecipeTickEvent> handler) {
+    public RecipePrimer addPostTickHandler(crafttweaker.util.IEventHandler<RecipeTickEvent> handler) {
         addRecipeEventHandler(RecipeTickEvent.class, event -> {
             if (event.phase != Phase.END) return;
             handler.handle(event);
@@ -323,25 +323,25 @@ public class RecipePrimer implements PreparedRecipe {
     }
 
     @ZenMethod
-    public RecipePrimer addFailureHandler(IEventHandler<RecipeFailureEvent> handler) {
-        addRecipeEventHandler(RecipeFailureEvent.class, handler);
+    public RecipePrimer addFailureHandler(crafttweaker.util.IEventHandler<RecipeFailureEvent> handler) {
+        addRecipeEventHandler(RecipeFailureEvent.class, handler::handle);
         return this;
     }
 
     @ZenMethod
-    public RecipePrimer addFinishHandler(IEventHandler<RecipeFinishEvent> handler) {
-        addRecipeEventHandler(RecipeFinishEvent.class, handler);
+    public RecipePrimer addFinishHandler(crafttweaker.util.IEventHandler<RecipeFinishEvent> handler) {
+        addRecipeEventHandler(RecipeFinishEvent.class, handler::handle);
         return this;
     }
 
     @ZenMethod
-    public RecipePrimer addFactoryStartHandler(IEventHandler<FactoryRecipeStartEvent> handler) {
-        addRecipeEventHandler(FactoryRecipeStartEvent.class, handler);
+    public RecipePrimer addFactoryStartHandler(crafttweaker.util.IEventHandler<FactoryRecipeStartEvent> handler) {
+        addRecipeEventHandler(FactoryRecipeStartEvent.class, handler::handle);
         return this;
     }
 
     @ZenMethod
-    public RecipePrimer addFactoryPreTickHandler(IEventHandler<FactoryRecipeTickEvent> handler) {
+    public RecipePrimer addFactoryPreTickHandler(crafttweaker.util.IEventHandler<FactoryRecipeTickEvent> handler) {
         addRecipeEventHandler(FactoryRecipeTickEvent.class, event -> {
             if (event.phase != Phase.START) {
                 return;
@@ -352,7 +352,7 @@ public class RecipePrimer implements PreparedRecipe {
     }
 
     @ZenMethod
-    public RecipePrimer addFactoryPostTickHandler(IEventHandler<FactoryRecipeTickEvent> handler) {
+    public RecipePrimer addFactoryPostTickHandler(crafttweaker.util.IEventHandler<FactoryRecipeTickEvent> handler) {
         addRecipeEventHandler(FactoryRecipeTickEvent.class, event -> {
             if (event.phase != Phase.END) {
                 return;
@@ -363,14 +363,14 @@ public class RecipePrimer implements PreparedRecipe {
     }
 
     @ZenMethod
-    public RecipePrimer addFactoryFailureHandler(IEventHandler<FactoryRecipeFailureEvent> handler) {
-        addRecipeEventHandler(FactoryRecipeFailureEvent.class, handler);
+    public RecipePrimer addFactoryFailureHandler(crafttweaker.util.IEventHandler<FactoryRecipeFailureEvent> handler) {
+        addRecipeEventHandler(FactoryRecipeFailureEvent.class, handler::handle);
         return this;
     }
 
     @ZenMethod
-    public RecipePrimer addFactoryFinishHandler(IEventHandler<FactoryRecipeFinishEvent> handler) {
-        addRecipeEventHandler(FactoryRecipeFinishEvent.class, handler);
+    public RecipePrimer addFactoryFinishHandler(crafttweaker.util.IEventHandler<FactoryRecipeFinishEvent> handler) {
+        addRecipeEventHandler(FactoryRecipeFinishEvent.class, handler::handle);
         return this;
     }
 

--- a/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/event/MMEvents.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/event/MMEvents.java
@@ -32,7 +32,7 @@ public class MMEvents {
         WAIT_FOR_MODIFY.add(() -> {
             DynamicMachine machine = MachineRegistry.getRegistry().getMachine(new ResourceLocation(ModularMachinery.MODID, machineRegistryName));
             if (machine != null) {
-                machine.addMachineEventHandler(MachineStructureFormedEvent.class, function);
+                machine.addMachineEventHandler(MachineStructureFormedEvent.class, function::handle);
             } else {
                 CraftTweakerAPI.logError("Could not find machine `" + machineRegistryName + "`!");
             }
@@ -44,7 +44,7 @@ public class MMEvents {
         WAIT_FOR_MODIFY.add(() -> {
             DynamicMachine machine = MachineRegistry.getRegistry().getMachine(new ResourceLocation(ModularMachinery.MODID, machineRegistryName));
             if (machine != null) {
-                machine.addMachineEventHandler(MachineStructureUpdateEvent.class, function);
+                machine.addMachineEventHandler(MachineStructureUpdateEvent.class, function::handle);
             } else {
                 CraftTweakerAPI.logError("Could not find machine `" + machineRegistryName + "`!");
             }
@@ -100,7 +100,7 @@ public class MMEvents {
         WAIT_FOR_MODIFY.add(() -> {
             DynamicMachine machine = MachineRegistry.getRegistry().getMachine(new ResourceLocation(ModularMachinery.MODID, machineRegistryName));
             if (machine != null) {
-                machine.addMachineEventHandler(ControllerGUIRenderEvent.class, function);
+                machine.addMachineEventHandler(ControllerGUIRenderEvent.class, function::handle);
             } else {
                 CraftTweakerAPI.logError("Could not find machine `" + machineRegistryName + "`!");
             }
@@ -116,7 +116,7 @@ public class MMEvents {
         WAIT_FOR_MODIFY.add(() -> {
             DynamicMachine machine = MachineRegistry.getRegistry().getMachine(new ResourceLocation(ModularMachinery.MODID, machineRegistryName));
             if (machine != null) {
-                machine.addMachineEventHandler(ControllerModelAnimationEvent.class, function);
+                machine.addMachineEventHandler(ControllerModelAnimationEvent.class, function::handle);
             } else {
                 CraftTweakerAPI.logError("Could not find machine `" + machineRegistryName + "`!");
             }
@@ -132,7 +132,7 @@ public class MMEvents {
         WAIT_FOR_MODIFY.add(() -> {
             DynamicMachine machine = MachineRegistry.getRegistry().getMachine(new ResourceLocation(ModularMachinery.MODID, machineRegistryName));
             if (machine != null) {
-                machine.addMachineEventHandler(ControllerModelGetEvent.class, function);
+                machine.addMachineEventHandler(ControllerModelGetEvent.class, function::handle);
             } else {
                 CraftTweakerAPI.logError("Could not find machine `" + machineRegistryName + "`!");
             }
@@ -144,7 +144,7 @@ public class MMEvents {
         WAIT_FOR_MODIFY.add(() -> {
             DynamicMachine machine = MachineRegistry.getRegistry().getMachine(new ResourceLocation(ModularMachinery.MODID, machineRegistryName));
             if (machine != null) {
-                machine.addMachineEventHandler(SmartInterfaceUpdateEvent.class, function);
+                machine.addMachineEventHandler(SmartInterfaceUpdateEvent.class, function::handle);
             } else {
                 CraftTweakerAPI.logError("Could not find machine `" + machineRegistryName + "`!");
             }

--- a/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
@@ -10,8 +10,8 @@ package hellfirepvp.modularmachinery.common.machine;
 
 import com.google.common.collect.Lists;
 import com.google.gson.*;
-import crafttweaker.util.IEventHandler;
 import github.kasuminova.mmce.common.concurrent.RecipeCraftingContextPool;
+import github.kasuminova.mmce.common.event.machine.IEventHandler;
 import github.kasuminova.mmce.common.event.machine.MachineEvent;
 import github.kasuminova.mmce.common.util.DynamicPattern;
 import hellfirepvp.modularmachinery.common.crafting.ActiveMachineRecipe;


### PR DESCRIPTION
Adds compat for GroovyScript 1.0.0. (Currently gets grs from local maven since i need to publish 1.0.1 first for some changes).

- [x] recipe builder
- [x] recipe events
- [x] machine events
- [ ] machine upgrade builder
- [ ] block array builder
- [ ] machine builder
- [ ] recipe modifier builder
- [ ] multiblock modifier builder

This is a working example of a basic recipe builder
```groovy
mods.modularmachinery.iron_centrifuge.recipeBuilder()
    .input(item('minecraft:diamond') * 3)
    .output(item('minecraft:clay_ball'))
    .energyInput(1000)
    .time(120)
    .register()
```

