### PR TITLE
Remove usage of GLSM push/popAttrib

### DIFF
--- a/src/main/java/com/cleanroommc/client/preview/renderer/scene/WorldSceneRenderer.java
+++ b/src/main/java/com/cleanroommc/client/preview/renderer/scene/WorldSceneRenderer.java
@@ -304,7 +304,7 @@ public abstract class WorldSceneRenderer {
         int width = positionedRect.getSize().width;
         int height = positionedRect.getSize().height;
 
-        GlStateManager.pushAttrib();
+        // GlStateManager.pushAttrib();
 
         Minecraft.getMinecraft().entityRenderer.disableLightmap();
         GlStateManager.disableLighting();
@@ -355,8 +355,9 @@ public abstract class WorldSceneRenderer {
         GlStateManager.enableBlend();
         GlStateManager.disableDepth();
 
-        //reset attributes
-        GlStateManager.popAttrib();
+        // TODO: Might need to properly reset remaining attributes?
+        // but this method shouldn't be used - see Forge#1637
+        // GlStateManager.popAttrib();
     }
 
     protected void drawWorld() {

--- a/src/main/java/kport/modularmagic/common/integration/jei/render/ConstellationRenderer.java
+++ b/src/main/java/kport/modularmagic/common/integration/jei/render/ConstellationRenderer.java
@@ -36,7 +36,6 @@ public class ConstellationRenderer implements IIngredientRenderer<Constellation>
         }
 
         GlStateManager.pushMatrix();
-        GlStateManager.pushAttrib();
 
         texBlack.bind();
         drawRect(xPosition, yPosition, 58, 58);
@@ -67,7 +66,6 @@ public class ConstellationRenderer implements IIngredientRenderer<Constellation>
             }, true, false);
         }
 
-        GlStateManager.popAttrib();
         GlStateManager.popMatrix();
     }
 


### PR DESCRIPTION
Just removing usage of `GlStateManager.push/popAttrib()`, see #115. I'm not experienced enough with OpenGL to see if there's any attributes that relied on being reset by `popAttrib`, so there might be some side-effects. I haven't noticed any visual issues before or after this change though, so this is more of a change just to be safe.