### PR TITLE
fix: avoid crash when mixinbooter not loaded

### DIFF
--- a/src/main/java/github/kasuminova/mmce/mixin/MMCEEarlyMixinLoader.java
+++ b/src/main/java/github/kasuminova/mmce/mixin/MMCEEarlyMixinLoader.java
@@ -1,22 +1,13 @@
 package github.kasuminova.mmce.mixin;
 
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
-import zone.rong.mixinbooter.IEarlyMixinLoader;
+import org.spongepowered.asm.mixin.Mixins;
 
 import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("unused")
-public class MMCEEarlyMixinLoader implements IEarlyMixinLoader, IFMLLoadingPlugin {
-
-    @Override
-    public List<String> getMixinConfigs() {
-        return Arrays.asList(
-                "mixins.mmce_minecraft.json"
-        );
-    }
+public class MMCEEarlyMixinLoader implements IFMLLoadingPlugin {
 
     @Override
     public String[] getASMTransformerClass() {
@@ -36,7 +27,7 @@ public class MMCEEarlyMixinLoader implements IEarlyMixinLoader, IFMLLoadingPlugi
 
     @Override
     public void injectData(final Map<String, Object> data) {
-
+        Mixins.addConfiguration("mixins.mmce_minecraft.json");
     }
 
     @Override


### PR DESCRIPTION
fix #139