### PR TITLE
Fix asset path error in DemonWillRenderer

### DIFF
--- a/src/main/java/kport/modularmagic/common/integration/jei/render/DemonWillRenderer.java
+++ b/src/main/java/kport/modularmagic/common/integration/jei/render/DemonWillRenderer.java
@@ -34,7 +34,7 @@ public class DemonWillRenderer implements IIngredientRenderer<DemonWill> {
             willType = ingredient.getWillType();
             ResourceLocation texture;
             if (willType != EnumDemonWillType.DEFAULT)
-                texture = new ResourceLocation(BloodMagic.MODID, "textures/items/soulgemgrand_" + ingredient.getWillType().name + "tilemachinecontroller.png");
+                texture = new ResourceLocation(BloodMagic.MODID, "textures/items/soulgemgrand_" + ingredient.getWillType().name + ".png");
             else
                 texture = new ResourceLocation(BloodMagic.MODID, "textures/items/soulgemgrand.png");
             willCrystal = JeiPlugin.GUI_HELPER.drawableBuilder(texture, 0, 0, 16, 16);


### PR DESCRIPTION
Fixed a bug which was introduced a while ago where the path to the BM assets for will crystals is wrong, causing all will types different from the default one to not render properly in JEI.