### PR TITLE
Fix SingleBlockModifier applying to all blocks of the same base type in certain circumstances

### DIFF
--- a/src/main/java/github/kasuminova/mmce/client/gui/widget/impl/preview/WorldSceneRendererWidget.java
+++ b/src/main/java/github/kasuminova/mmce/client/gui/widget/impl/preview/WorldSceneRendererWidget.java
@@ -177,7 +177,10 @@ public class WorldSceneRendererWidget extends DynamicWidget {
         Map<BlockPos, BlockArray.BlockInformation> pattern = this.pattern.getPattern();
         machine.getModifiersAsMatchingReplacements().forEach((pos, infoList) -> infoList.forEach(info -> {
             if (pattern.containsKey(pos)) {
-                pattern.get(pos).addMatchingStates(info.getMatchingStates());
+                // Clone the block info, we don't want to modify the canonical instance.
+                BlockArray.BlockInformation newInfo = pattern.get(pos).copy();
+                newInfo.addMatchingStates(info.getMatchingStates());
+                this.pattern.addBlock(pos, newInfo);
             } else {
                 this.pattern.addBlock(pos, info);
             }

--- a/src/main/java/hellfirepvp/modularmachinery/client/util/DynamicMachineRenderContext.java
+++ b/src/main/java/hellfirepvp/modularmachinery/client/util/DynamicMachineRenderContext.java
@@ -136,9 +136,12 @@ public class DynamicMachineRenderContext {
             for (BlockArray.BlockInformation info : informationList) {
                 Map<BlockPos, BlockArray.BlockInformation> pattern = blockArray.getPattern();
                 if (pattern.containsKey(pos)) {
-                    pattern.get(pos).addMatchingStates(info.getMatchingStates());
+                    // Clone the block info, we don't want to modify the canonical instance.
+                    BlockArray.BlockInformation newInfo = pattern.get(pos).copy();
+                    newInfo.addMatchingStates(info.getMatchingStates());
+                    blockArray.addBlock(pos, newInfo);
                 } else {
-                    pattern.put(pos, info);
+                    blockArray.addBlock(pos, info);
                 }
             }
         }

--- a/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
@@ -247,7 +247,7 @@ public class DynamicMachine extends AbstractMachine {
             return out;
         }
 
-        private static void addModifierWithPattern(DynamicMachine machine, TaggedPositionBlockArray pattern, SingleBlockModifierReplacement mod, JsonObject part) throws JsonParseException {
+        private static void addModifierWithPattern(DynamicMachine machine, SingleBlockModifierReplacement mod, JsonObject part) throws JsonParseException {
             List<Integer> avX = new ArrayList<>();
             List<Integer> avY = new ArrayList<>();
             List<Integer> avZ = new ArrayList<>();
@@ -259,10 +259,6 @@ public class DynamicMachine extends AbstractMachine {
                 if (permutation.getX() == 0 && permutation.getY() == 0 && permutation.getZ() == 0) {
                     continue; //We're not going to overwrite the controller.
                 }
-                // Clone the block info, we don't want to modify the canonical instance.
-                BlockArray.BlockInformation info = pattern.getPattern().get(permutation).copy();
-                info.addMatchingStates(mod.getBlockInformation().getMatchingStates());
-                pattern.addBlock(permutation, info);
                 machine.modifiers.putIfAbsent(permutation, Lists.newArrayList());
                 machine.modifiers.get(permutation).add(mod.setPos(permutation));
             }
@@ -379,7 +375,7 @@ public class DynamicMachine extends AbstractMachine {
 
             // Modifiers
             if (root.has("modifiers")) {
-                addModifiers(context, root, machine, machine.pattern);
+                addModifiers(context, root, machine);
             }
 
             // DynamicPatterns
@@ -554,7 +550,7 @@ public class DynamicMachine extends AbstractMachine {
             }
         }
 
-        private static void addModifiers(final JsonDeserializationContext context, final JsonObject root, final DynamicMachine machine, final TaggedPositionBlockArray pattern) {
+        private static void addModifiers(final JsonDeserializationContext context, final JsonObject root, final DynamicMachine machine) {
             JsonElement partModifiers = root.get("modifiers");
             if (!partModifiers.isJsonArray()) {
                 throw new JsonParseException("'modifiers' has to be an array of modifiers!");
@@ -565,7 +561,7 @@ public class DynamicMachine extends AbstractMachine {
                 if (!modifier.isJsonObject()) {
                     throw new JsonParseException("Elements of 'modifiers' have to be objects!");
                 }
-                addModifierWithPattern(machine, pattern, context.deserialize(modifier.getAsJsonObject(), SingleBlockModifierReplacement.class), modifier.getAsJsonObject());
+                addModifierWithPattern(machine, context.deserialize(modifier.getAsJsonObject(), SingleBlockModifierReplacement.class), modifier.getAsJsonObject());
             }
         }
 

--- a/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
@@ -247,7 +247,7 @@ public class DynamicMachine extends AbstractMachine {
             return out;
         }
 
-        private static void addModifierWithPattern(DynamicMachine machine, SingleBlockModifierReplacement mod, JsonObject part) throws JsonParseException {
+        private static void addModifierWithPattern(DynamicMachine machine, TaggedPositionBlockArray pattern, SingleBlockModifierReplacement mod, JsonObject part) throws JsonParseException {
             List<Integer> avX = new ArrayList<>();
             List<Integer> avY = new ArrayList<>();
             List<Integer> avZ = new ArrayList<>();
@@ -259,6 +259,10 @@ public class DynamicMachine extends AbstractMachine {
                 if (permutation.getX() == 0 && permutation.getY() == 0 && permutation.getZ() == 0) {
                     continue; //We're not going to overwrite the controller.
                 }
+                // Clone the block info, we don't want to modify the canonical instance.
+                BlockArray.BlockInformation info = pattern.getPattern().get(permutation).copy();
+                info.addMatchingStates(mod.getBlockInformation().getMatchingStates());
+                pattern.addBlock(permutation, info);
                 machine.modifiers.putIfAbsent(permutation, Lists.newArrayList());
                 machine.modifiers.get(permutation).add(mod.setPos(permutation));
             }
@@ -375,7 +379,7 @@ public class DynamicMachine extends AbstractMachine {
 
             // Modifiers
             if (root.has("modifiers")) {
-                addModifiers(context, root, machine);
+                addModifiers(context, root, machine, machine.pattern);
             }
 
             // DynamicPatterns
@@ -550,7 +554,7 @@ public class DynamicMachine extends AbstractMachine {
             }
         }
 
-        private static void addModifiers(final JsonDeserializationContext context, final JsonObject root, final DynamicMachine machine) {
+        private static void addModifiers(final JsonDeserializationContext context, final JsonObject root, final DynamicMachine machine, final TaggedPositionBlockArray pattern) {
             JsonElement partModifiers = root.get("modifiers");
             if (!partModifiers.isJsonArray()) {
                 throw new JsonParseException("'modifiers' has to be an array of modifiers!");
@@ -561,7 +565,7 @@ public class DynamicMachine extends AbstractMachine {
                 if (!modifier.isJsonObject()) {
                     throw new JsonParseException("Elements of 'modifiers' have to be objects!");
                 }
-                addModifierWithPattern(machine, context.deserialize(modifier.getAsJsonObject(), SingleBlockModifierReplacement.class), modifier.getAsJsonObject());
+                addModifierWithPattern(machine, pattern, context.deserialize(modifier.getAsJsonObject(), SingleBlockModifierReplacement.class), modifier.getAsJsonObject());
             }
         }
 


### PR DESCRIPTION
Fixes #144. You can see the issue for more details, but in summary:
- As of 2.0.3, any `SingleBlockModifierReplacement` declared would be allowed in any position where the base block was (after certain rendering).
- This was a bug introduced by the canonicalization of `BlockArray.BlockInformation`.
- This bug is only exhibited after doing one of 2 things: (1) Viewing the machine's JEI preview, or (2) Rendering the in-world placement preview of the machine from the blueprint

This PR fixes the issue by ~~directly adding the modifier to the machine's pattern on deserialization/reload~~ copying the `BlockInformation` saved in the pattern before adding the modifier's blockstate. Note this is needed so we don't modify the canonical instance shared by other block positions.