### PR TITLE
Fix ME fluid output voiding

### DIFF
--- a/src/main/java/github/kasuminova/mmce/common/util/AEFluidInventoryUpgradeable.java
+++ b/src/main/java/github/kasuminova/mmce/common/util/AEFluidInventoryUpgradeable.java
@@ -21,7 +21,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * From: <a href="https://github.com/PrototypeTrousers/Applied-Energistics-2/blob/AE2-Omnifactory/src/main/java/appeng/fluids/util/AEFluidInventory.java">...</a>
  */
 @SuppressWarnings("unchecked")
-public class AEFluidInventoryUpgradeable implements IAEFluidTank, ReadWriteLockProvider {
+public class AEFluidInventoryUpgradeable implements IAEFluidTank, ReadWriteLockProvider, IOneToOneFluidHandler {
     private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
 
     private final AtomicReference<IAEFluidStack>[] fluids;
@@ -54,6 +54,7 @@ public class AEFluidInventoryUpgradeable implements IAEFluidTank, ReadWriteLockP
         }
     }
 
+    @Override
     public boolean isOneFluidOneSlot() {
         return oneFluidOneSlot;
     }

--- a/src/main/java/github/kasuminova/mmce/common/util/AEFluidInventoryUpgradeable.java
+++ b/src/main/java/github/kasuminova/mmce/common/util/AEFluidInventoryUpgradeable.java
@@ -7,6 +7,7 @@ import appeng.fluids.util.IAEFluidInventory;
 import appeng.fluids.util.IAEFluidTank;
 import appeng.util.Platform;
 import github.kasuminova.mmce.common.util.concurrent.ReadWriteLockProvider;
+import hellfirepvp.modularmachinery.common.util.HybridFluidUtils;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
@@ -204,18 +205,9 @@ public class AEFluidInventoryUpgradeable implements IAEFluidTank, ReadWriteLockP
         try {
             (doFill ? rwLock.writeLock() : rwLock.readLock()).lock();
 
-            if (oneFluidOneSlot) {
-                int found = -1;
-                for (int i = 0; i < fluids.length; i++) {
-                    final IAEFluidStack fluidInSlot = getFluid(i);
-                    if (fluidInSlot != null && fluidInSlot.getFluid() == insert.getFluid()) {
-                        found = i;
-                        break;
-                    }
-                }
-                if (found != -1) {
-                    return this.fill(found, insert, doFill);
-                }
+            int found = HybridFluidUtils.findSlotWithFluid(this, getTankProperties(), insert);
+            if (found >= 0) {
+                return this.fill(found, insert, doFill);
             }
 
             int totalFillAmount = 0;

--- a/src/main/java/github/kasuminova/mmce/common/util/IOneToOneFluidHandler.java
+++ b/src/main/java/github/kasuminova/mmce/common/util/IOneToOneFluidHandler.java
@@ -1,0 +1,14 @@
+package github.kasuminova.mmce.common.util;
+
+/**
+ * Implement this interface for a multi-fluid tank that only allows one slot per type of fluid.
+ */
+public interface IOneToOneFluidHandler {
+
+    /**
+     * Returns whether distinct slots map to distinct types of fluids.
+     * @return true if the mapping is one-to-one
+     */
+    boolean isOneFluidOneSlot();
+
+}

--- a/src/main/java/github/kasuminova/mmce/common/util/MultiFluidTank.java
+++ b/src/main/java/github/kasuminova/mmce/common/util/MultiFluidTank.java
@@ -1,5 +1,6 @@
 package github.kasuminova.mmce.common.util;
 
+import hellfirepvp.modularmachinery.common.util.HybridFluidUtils;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
@@ -10,7 +11,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 @SuppressWarnings("unused")
-public class MultiFluidTank implements IFluidHandler {
+public class MultiFluidTank implements IFluidHandler, IOneToOneFluidHandler {
     private final FluidStack[] contents;
     private final IFluidTankProperties[] props;
     private int capacity;
@@ -67,6 +68,11 @@ public class MultiFluidTank implements IFluidHandler {
     }
 
     @Override
+    public boolean isOneFluidOneSlot() {
+        return oneToOne;
+    }
+
+    @Override
     public IFluidTankProperties[] getTankProperties() {
         return props;
     }
@@ -79,20 +85,9 @@ public class MultiFluidTank implements IFluidHandler {
 
         final FluidStack insert = fluid.copy();
 
-        if (oneToOne) {
-            // Find the distinct slot
-            int foundSlot = -1;
-            for (int i = 0; i < props.length; i++) {
-                FluidStack fluidInSlot = props[i].getContents();
-                if (fluidInSlot != null && fluidInSlot.getFluid() == fluid.getFluid()) {
-                    foundSlot = i;
-                    break;
-                }
-            }
-            if (foundSlot >= 0) {
-                return fill(foundSlot, insert, doFill);
-            }
-            // Didn't find existing fluid, resume normal logic.
+        int foundSlot = HybridFluidUtils.findSlotWithFluid(this, props, fluid);
+        if (foundSlot >= 0) {
+            return fill(foundSlot, insert, doFill);
         }
 
         int totalFillAmount = 0;

--- a/src/main/java/hellfirepvp/modularmachinery/common/util/HybridFluidUtils.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/util/HybridFluidUtils.java
@@ -3,6 +3,7 @@ package hellfirepvp.modularmachinery.common.util;
 import com.google.common.collect.Lists;
 import github.kasuminova.mmce.common.concurrent.Sync;
 import github.kasuminova.mmce.common.util.IExtendedGasHandler;
+import github.kasuminova.mmce.common.util.IOneToOneFluidHandler;
 import github.kasuminova.mmce.common.util.MultiFluidTank;
 import github.kasuminova.mmce.common.util.MultiGasTank;
 import hellfirepvp.modularmachinery.common.crafting.helper.ProcessingComponent;
@@ -12,6 +13,7 @@ import mekanism.api.gas.GasStack;
 import mekanism.api.gas.IGasHandler;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
 import net.minecraftforge.fml.common.Optional;
 
 import javax.annotation.Nonnull;
@@ -133,6 +135,20 @@ public class HybridFluidUtils {
                 break;
             }
         }
+    }
+
+    public static int findSlotWithFluid(final IOneToOneFluidHandler handler, final IFluidTankProperties[] props, final FluidStack fluid) {
+        int found = -1;
+        if (handler.isOneFluidOneSlot()) {
+            for (int i = 0; i < props.length; i++) {
+                FluidStack fluidInSlot = props[i].getContents();
+                if (fluidInSlot != null && fluidInSlot.getFluid() == fluid.getFluid()) {
+                    found = i;
+                    break;
+                }
+            }
+        }
+        return found;
     }
 
     @Nonnull


### PR DESCRIPTION
This PR fixes the ME fluid output bus voiding excess due to its one-to-one enforcement. The issue was if a modular machine had an ME fluid output, it would never stop outputting fluid to one slot and void the excess output. 

The cause was `MultiFluidTank` missing handling for one-to-one fluid tanks (ME fluid output), so `RecipeCraftingContext#canFinishCrafting()` passed the check by checking the copied provided component (type `MultiFluidTank`), but `RecipeCraftingContext#finishCrafting()` did not due to using the true provided component (type `AEFluidInventoryUpgradeable`).