### PR TITLE
Potential fix to machinery hatches

### DIFF
--- a/src/main/java/github/kasuminova/mmce/common/tile/MEFluidInputBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/tile/MEFluidInputBus.java
@@ -188,7 +188,7 @@ public class MEFluidInputBus extends MEFluidBus {
 
     @Override
     public void markNoUpdate() {
-        if (proxy.isActive() && needsUpdate()) {
+        if (needsUpdate()) {
             try {
                 proxy.getTick().alertDevice(proxy.getNode());
             } catch (GridAccessException e) {

--- a/src/main/java/github/kasuminova/mmce/common/tile/MEFluidOutputBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/tile/MEFluidOutputBus.java
@@ -109,7 +109,7 @@ public class MEFluidOutputBus extends MEFluidBus {
 
     @Override
     public void markNoUpdate() {
-        if (proxy.isActive() && hasFluid()) {
+        if (hasFluid()) {
             try {
                 proxy.getTick().alertDevice(proxy.getNode());
             } catch (GridAccessException e) {

--- a/src/main/java/github/kasuminova/mmce/common/tile/MEGasInputBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/tile/MEGasInputBus.java
@@ -196,7 +196,7 @@ public class MEGasInputBus extends MEGasBus {
 
     @Override
     public void markNoUpdate() {
-        if (proxy.isActive() && needsUpdate()) {
+        if (needsUpdate()) {
             try {
                 proxy.getTick().alertDevice(proxy.getNode());
             } catch (GridAccessException e) {

--- a/src/main/java/github/kasuminova/mmce/common/tile/MEGasOutputBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/tile/MEGasOutputBus.java
@@ -110,7 +110,7 @@ public class MEGasOutputBus extends MEGasBus {
 
     @Override
     public void markNoUpdate() {
-        if (proxy.isActive() && hasGas()) {
+        if (hasGas()) {
             try {
                 proxy.getTick().alertDevice(proxy.getNode());
             } catch (GridAccessException e) {

--- a/src/main/java/github/kasuminova/mmce/common/tile/MEItemInputBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/tile/MEItemInputBus.java
@@ -246,7 +246,7 @@ public class MEItemInputBus extends MEItemBus {
 
     @Override
     public void markNoUpdate() {
-        if (proxy.isActive() && hasChangedSlots()) {
+        if (hasChangedSlots()) {
             try {
                 proxy.getTick().alertDevice(proxy.getNode());
             } catch (GridAccessException e) {

--- a/src/main/java/github/kasuminova/mmce/common/tile/MEItemOutputBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/tile/MEItemOutputBus.java
@@ -121,7 +121,7 @@ public class MEItemOutputBus extends MEItemBus {
 
     @Override
     public void markNoUpdate() {
-        if (proxy.isActive() && hasChangedSlots()) {
+        if (hasChangedSlots()) {
             try {
                 proxy.getTick().alertDevice(proxy.getNode());
             } catch (GridAccessException e) {


### PR DESCRIPTION
In some scenarios, machinery hatches stop working and require manual intervention to re-enable them (for example, fluid inputs stop providing the configured fluids). From debugging, it appears that all hatches are sleeping on startup, and in certain cases, they are never woken up.

There are multiple layers of complexity here, from MMCE’s TileEntitySynchronized implementation to AE2’s tick rate manager, which I didn’t fully investigate. However, I had a world where I could consistently reproduce the issue with some fluid machinery inputs by simply leaving and rejoining the world. Applying the changes in this PR resolved the issue in that scenario.

I assume the device needs to be alerted at least once to exit sleep mode, after which AE2’s tick rate manager handles it.

While I’m sure there are more refined solutions (and this one might not fix every edge case, since technically alertDevice will fail if the grid is null), this could be a good first step toward making machinery hatches more reliable.

Anyone familiar with either MMCE or AE2’s tick rate manager is welcome to provide feedback.