### PR TITLE
Changed the interaction with the configured items in machinery item hatches

### DIFF
--- a/src/main/java/github/kasuminova/mmce/client/gui/GuiMEItemInputBus.java
+++ b/src/main/java/github/kasuminova/mmce/client/gui/GuiMEItemInputBus.java
@@ -31,83 +31,29 @@ import java.util.Locale;
 public class GuiMEItemInputBus extends GuiMEItemBus {
     private static final ResourceLocation TEXTURES_INPUT_BUS = new ResourceLocation(ModularMachinery.MODID, "textures/gui/meiteminputbus.png");
 
-    private int invActionAmount = 0;
-
     public GuiMEItemInputBus(final MEItemInputBus te, final EntityPlayer player) {
         super(new ContainerMEItemInputBus(te, player));
         this.ySize = 204;
-    }
-
-    private static int getAddAmount() {
-        int addAmount;
-        // SHIFT + CTRL + ALT 1000000
-        // ALT + CTRL         100000
-        // ALT + SHIFT        10000
-        // SHIFT + CTRL       1000
-        // CTRL               100
-        // SHIFT              10
-        if (isShiftDown() && isControlDown() && isAltDown()) {
-            addAmount = 1_000_000;
-        } else if (isAltDown() && isControlDown()) {
-            addAmount = 100_000;
-        } else if (isAltDown() && isShiftDown()) {
-            addAmount = 10_000;
-        } else if (isShiftDown() && isControlDown()) {
-            addAmount = 1_000;
-        } else if (isControlDown()) {
-            addAmount = 100;
-        } else if (isShiftDown()) {
-            addAmount = 10;
-        } else {
-            addAmount = 1;
-        }
-        return addAmount;
     }
 
     private static List<String> getAddActionInfo() {
         List<String> tooltip = new ArrayList<>();
         tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action"));
         // Quite a sight, isn't it?
-        String addAmount = MiscUtils.formatDecimal(getAddAmount());
-        if (isShiftDown() && isControlDown() && isAltDown()) {
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.increase",
-                "SHIFT + CTRL + ALT", addAmount));
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.decrease",
-                "SHIFT + CTRL + ALT", addAmount));
-        } else if (isAltDown() && isControlDown()) {
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.increase",
-                "CTRL + ALT", addAmount));
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.decrease",
-                "CTRL + ALT", addAmount));
-        } else if (isAltDown() && isShiftDown()) {
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.increase",
-                "SHIFT + ALT", addAmount));
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.decrease",
-                "SHIFT + ALT", addAmount));
-        } else if (isShiftDown() && isControlDown()) {
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.increase",
-                "SHIFT + CTRL", addAmount));
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.decrease",
-                "SHIFT + CTRL", addAmount));
-        } else if (isControlDown()) {
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.increase",
-                "CTRL", addAmount));
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.decrease",
-                "CTRL", addAmount));
-        } else if (isShiftDown()) {
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.increase",
-                "SHIFT", addAmount));
-            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.decrease",
-                "SHIFT", addAmount));
+        // It was truly a beautiful sight...
+
+        if (isShiftDown() && isControlDown()) {
+            String keyCombination = "SHIFT + CTRL";
+            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.multiply",
+                    keyCombination));
+            tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.divide",
+                    keyCombination));
         } else {
             tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.increase.normal"));
             tooltip.add(TextFormatting.GRAY + I18n.format("gui.meiteminputbus.inv_action.decrease.normal"));
         }
-        return tooltip;
-    }
 
-    private static boolean isAltDown() {
-        return Keyboard.isKeyDown(Keyboard.KEY_LMENU) || Keyboard.isKeyDown(Keyboard.KEY_RMENU);
+        return tooltip;
     }
 
     private static boolean isControlDown() {
@@ -146,29 +92,53 @@ public class GuiMEItemInputBus extends GuiMEItemBus {
             return;
         }
 
-        int amount = wheel < 0 ? -getAddAmount() : getAddAmount();
         int stackCount = stack.getCount();
+        int countToSend = getUpdatedCount(isScrollingUp(wheel), stackCount);
 
-        if (amount > 0) {
-            if (stackCount + amount > slot.getSlotStackLimit()) {
+        if (countToSend > 0) {
+            if (countToSend > slot.getSlotStackLimit()) {
                 return;
             }
-        } else if (stackCount - amount <= 0) {
-            return;
         }
 
-        this.invActionAmount += amount;
-        ClientProxy.clientScheduler.addRunnable(() -> sendInvActionToServer(slot.slotNumber), 0);
+        ClientProxy.clientScheduler.addRunnable(() -> sendInvActionToServer(slot.slotNumber, countToSend), 0);
     }
 
-    public void sendInvActionToServer(int slotNumber) {
-        if (invActionAmount == 0) {
+    private boolean isScrollingUp(int wheel) {
+        return wheel >= 0;
+    }
+
+    private int getUpdatedCount(boolean isScrollingUp, int currentAmount) {
+        if (isShiftDown() && isControlDown()) {
+            if (isScrollingUp) {
+                // Overflow protection
+                if (currentAmount <= Integer.MAX_VALUE / 2) {
+                    return 2 * currentAmount;
+                }
+                return Integer.MAX_VALUE;
+            } else {
+                return Math.max(1, currentAmount / 2);
+            }
+        } else {
+            if (isScrollingUp) {
+                // Overflow protection
+                if (currentAmount < Integer.MAX_VALUE) {
+                    return 1 + currentAmount;
+                }
+                return Integer.MAX_VALUE;
+            } else {
+                return Math.max(1, currentAmount - 1);
+            }
+        }
+    }
+
+    public void sendInvActionToServer(int slotNumber, int amountToSend) {
+        if (amountToSend == 0) {
             return;
         }
         ModularMachinery.NET_CHANNEL.sendToServer(new PktMEInputBusInvAction(
-            invActionAmount, slotNumber
+            amountToSend, slotNumber
         ));
-        invActionAmount = 0;
     }
 
     @Override

--- a/src/main/java/github/kasuminova/mmce/common/network/PktMEInputBusInvAction.java
+++ b/src/main/java/github/kasuminova/mmce/common/network/PktMEInputBusInvAction.java
@@ -11,26 +11,26 @@ import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 
 public class PktMEInputBusInvAction implements IMessage, IMessageHandler<PktMEInputBusInvAction, IMessage> {
-    private int addAmount = 0;
+    private int newAmount = 0;
     private int slotID    = 0;
 
     public PktMEInputBusInvAction() {
     }
 
-    public PktMEInputBusInvAction(final int addAmount, final int slotID) {
-        this.addAmount = addAmount;
+    public PktMEInputBusInvAction(final int newAmount, final int slotID) {
+        this.newAmount = newAmount;
         this.slotID = slotID;
     }
 
     @Override
     public void fromBytes(final ByteBuf buf) {
-        this.addAmount = buf.readInt();
+        this.newAmount = buf.readInt();
         this.slotID = buf.readInt();
     }
 
     @Override
     public void toBytes(final ByteBuf buf) {
-        buf.writeInt(addAmount);
+        buf.writeInt(newAmount);
         buf.writeInt(slotID);
     }
 
@@ -51,20 +51,15 @@ public class PktMEInputBusInvAction implements IMessage, IMessageHandler<PktMEIn
             return null;
         }
 
-        int addAmount = message.addAmount;
-        if (addAmount == 0) {
+        int newAmount = message.newAmount;
+        if (newAmount == 0) {
             return null;
         }
 
-        int count = stack.getCount();
-        if (addAmount > 0) {
-            stack.grow(Math.min(slot.getSlotStackLimit() - count, addAmount));
-            slot.onSlotChanged();
-        } else {
-            int decrAmount = -addAmount;
-            stack.shrink(Math.min(count - 1, decrAmount));
-            slot.onSlotChanged();
-        }
+        ItemStack newStack = stack.copy();
+        newStack.setCount(newAmount);
+        slot.putStack(newStack);
+        slot.onSlotChanged();
 
         return null;
     }

--- a/src/main/resources/assets/modularmachinery/lang/en_US.lang
+++ b/src/main/resources/assets/modularmachinery/lang/en_US.lang
@@ -59,11 +59,13 @@ gui.upgradebus.incompatible=§eWarning: %s is not compatible with this machinery
 gui.meitemoutputbus.title=ME Machinery Item Output Bus
 gui.meiteminputbus.title=ME Machinery Item Input Bus
 
-gui.meiteminputbus.inv_action=Use the scroll wheel and the SHIFT, CONTROL, ALT key combination to modify the number of marked items.
+gui.meiteminputbus.inv_action=Use the scroll wheel and the SHIFT and CONTROL key combination to modify the number of marked items.
 gui.meiteminputbus.inv_action.increase.normal=Scroll the wheel up to increase the number of items by 1.
 gui.meiteminputbus.inv_action.decrease.normal=Scroll the wheel down or right-click on an item to decrease the number of items by 1.
 gui.meiteminputbus.inv_action.increase=Press the %s key combination to increase the number of %s items while the wheel is scrolling up.
 gui.meiteminputbus.inv_action.decrease=Press the %s key combination to decrease the number of %s items while the wheel is scrolling up.
+gui.meiteminputbus.inv_action.multiply=Press the %s key combination to double the number of items while the wheel is scrolling up.
+gui.meiteminputbus.inv_action.divide=Press the %s key combination to halve the number of items while the wheel is scrolling down.
 gui.meiteminputbus.items_marked=Items marked: %s
 gui.meitembus.item_cached=Items Cached: %s
 gui.meitembus.nbt_stored=Items have been stored internally.


### PR DESCRIPTION
Currently, MMCE exposes quite a few different key combinations to increase or decrease the number of items configured in machinery input hatches. I think this feature is not very coherent and breaks consistency with how similar AE2 devices work. This PR harmonizes the behavior of machinery input hatches to align with AE2: SHIFT+UP increases by 1, SHIFT+DOWN decreases by 1, SHIFT+CTRL+UP doubles the value, and SHIFT+CTRL+DOWN halves it.
I believe this change makes machinery input hatch configuration more consistent, and even if larger amounts are required, Integer.MAX_VALUE can still be reached in just ~20 scrolls up.