### PR TITLE
add RecipePrimer: consumeDurability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("maven-publish")
     id("org.jetbrains.gradle.plugin.idea-ext") version "1.1.7"
     id("eclipse")
-    id("com.gtnewhorizons.retrofuturagradle") version "1.3.19"
+    id("com.gtnewhorizons.retrofuturagradle") version "1.4.0"
 }
 
 // Project properties
@@ -156,8 +156,7 @@ repositories {
     }
     maven {
         name = "GTNH Maven"
-        url = uri("http://jenkins.usrv.eu:8081/nexus/content/groups/public/")
-        isAllowInsecureProtocol = true
+        url = uri("https://nexus.gtnewhorizons.com/repository/public/")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,11 +13,11 @@ pluginManagement {
         maven {
             // RetroFuturaGradle
             name = "GTNH Maven"
-            url = uri("http://jenkins.usrv.eu:8081/nexus/content/groups/public/")
+            url = uri("https://nexus.gtnewhorizons.com/repository/public/")
             isAllowInsecureProtocol = true
             mavenContent {
+                includeGroupByRegex("com\\.gtnewhorizons\\..+")
                 includeGroup("com.gtnewhorizons")
-                includeGroup("com.gtnewhorizons.retrofuturagradle")
             }
         }
         gradlePluginPortal()

--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/requirement/RequirementItem.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/requirement/RequirementItem.java
@@ -124,6 +124,14 @@ public class RequirementItem extends ComponentRequirement.MultiCompParallelizabl
         this.consumeDurability = Math.max(0, durability);
     }
 
+    public boolean supportsDurability() {
+        return switch (this.requirementType) {
+            case ITEMSTACKS -> !this.required.isEmpty() && this.required.isItemStackDamageable();
+            case OREDICT -> ItemUtils.hasDamageableEntry(this.oreDictName);
+            default -> false;
+        };
+    }
+
     @Override
     public int getSortingWeight() {
         return PRIORITY_WEIGHT_ITEM;

--- a/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/RecipePrimer.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/RecipePrimer.java
@@ -202,10 +202,17 @@ public class RecipePrimer implements PreparedRecipe {
                 CraftTweakerAPI.logWarning("[ModularMachinery] consumeDurability(int) only can be applied to item inputs!");
                 return this;
             }
+            int safeDurability = durability;
             if (durability < 0) {
                 CraftTweakerAPI.logWarning("[ModularMachinery] consumeDurability(int) requires a non-negative durability value!");
+                safeDurability = 0;
             }
-            reqItem.setConsumeDurability(durability);
+            if (safeDurability > 0 && !reqItem.supportsDurability()) {
+                CraftTweakerAPI.logWarning("[ModularMachinery] consumeDurability(int) only applies to items with durability; a component will be ignored.");
+                reqItem.setConsumeDurability(0);
+                return this;
+            }
+            reqItem.setConsumeDurability(safeDurability);
         } else {
             CraftTweakerAPI.logWarning("[ModularMachinery] consumeDurability(int) only can be applied to `Item`!");
         }

--- a/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/RecipePrimer.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/integration/crafttweaker/RecipePrimer.java
@@ -195,6 +195,23 @@ public class RecipePrimer implements PreparedRecipe {
         return this;
     }
 
+    @ZenMethod
+    public RecipePrimer consumeDurability(int durability) {
+        if (lastComponent instanceof RequirementItem reqItem) {
+            if (reqItem.getActionType() != IOType.INPUT) {
+                CraftTweakerAPI.logWarning("[ModularMachinery] consumeDurability(int) only can be applied to item inputs!");
+                return this;
+            }
+            if (durability < 0) {
+                CraftTweakerAPI.logWarning("[ModularMachinery] consumeDurability(int) requires a non-negative durability value!");
+            }
+            reqItem.setConsumeDurability(durability);
+        } else {
+            CraftTweakerAPI.logWarning("[ModularMachinery] consumeDurability(int) only can be applied to `Item`!");
+        }
+        return this;
+    }
+
     /**
      * <p>为某个输入或输出设置特定触发时间。</p>
      * <p>注意：如果设置了触发时间，则配方在其他时间不会触发任何消耗或产出动作。</p>

--- a/src/main/java/hellfirepvp/modularmachinery/common/util/ItemUtils.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/util/ItemUtils.java
@@ -21,6 +21,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntityFurnace;
+import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -238,6 +239,31 @@ public class ItemUtils {
             return 0;
         }
         return damageAllInternal(handler, contents, amount, damagePerUse);
+    }
+
+    public static boolean hasDamageableEntry(final String oreDictName) {
+        if (oreDictName == null || oreDictName.isEmpty()) {
+            return false;
+        }
+        NonNullList<ItemStack> entries = OreDictionary.getOres(oreDictName);
+        for (ItemStack entry : entries) {
+            if (entry.isEmpty()) {
+                continue;
+            }
+            if (entry.isItemStackDamageable()) {
+                return true;
+            }
+            if (entry.getItemDamage() == OreDictionary.WILDCARD_VALUE && entry.getItem().getCreativeTab() != null) {
+                NonNullList<ItemStack> subItems = NonNullList.create();
+                entry.getItem().getSubItems(entry.getItem().getCreativeTab(), subItems);
+                for (ItemStack subEntry : subItems) {
+                    if (!subEntry.isEmpty() && subEntry.isItemStackDamageable()) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     public static int insertAll(@Nonnull ItemStack stack, IItemHandlerModifiable handler, int maxInsert) {

--- a/src/main/java/hellfirepvp/modularmachinery/common/util/ItemUtils.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/util/ItemUtils.java
@@ -196,6 +196,50 @@ public class ItemUtils {
         return consumeAllInternal(handler, contents, amount);
     }
 
+    public static int damageAll(IItemHandlerModifiable handler, ItemStack toDamage, int amount, int damagePerUse, AdvancedItemChecker itemChecker, TileMultiblockMachineController controller) {
+        if (amount <= 0 || damagePerUse <= 0) {
+            return 0;
+        }
+        Int2ObjectMap<ItemStack> contents = findItemsIndexedInInventory(handler, toDamage, false, itemChecker, controller);
+        if (contents.isEmpty()) {
+            return 0;
+        }
+        return damageAllInternal(handler, contents, amount, damagePerUse);
+    }
+
+    public static int damageAll(IItemHandlerModifiable handler, ItemStack toDamage, int amount, int damagePerUse, @Nullable NBTTagCompound matchNBTTag) {
+        if (amount <= 0 || damagePerUse <= 0) {
+            return 0;
+        }
+        Int2ObjectMap<ItemStack> contents = findItemsIndexedInInventory(handler, toDamage, false, matchNBTTag);
+        if (contents.isEmpty()) {
+            return 0;
+        }
+        return damageAllInternal(handler, contents, amount, damagePerUse);
+    }
+
+    public static int damageAll(IItemHandlerModifiable handler, String oreName, int amount, int damagePerUse, AdvancedItemChecker itemChecker, TileMultiblockMachineController controller) {
+        if (amount <= 0 || damagePerUse <= 0) {
+            return 0;
+        }
+        Int2ObjectMap<ItemStack> contents = findItemsIndexedInInventoryOreDict(handler, oreName, itemChecker, controller);
+        if (contents.isEmpty()) {
+            return 0;
+        }
+        return damageAllInternal(handler, contents, amount, damagePerUse);
+    }
+
+    public static int damageAll(IItemHandlerModifiable handler, String oreName, int amount, int damagePerUse, @Nullable NBTTagCompound matchNBTTag) {
+        if (amount <= 0 || damagePerUse <= 0) {
+            return 0;
+        }
+        Int2ObjectMap<ItemStack> contents = findItemsIndexedInInventoryOreDict(handler, oreName, matchNBTTag);
+        if (contents.isEmpty()) {
+            return 0;
+        }
+        return damageAllInternal(handler, contents, amount, damagePerUse);
+    }
+
     public static int insertAll(@Nonnull ItemStack stack, IItemHandlerModifiable handler, int maxInsert) {
         if (stack.getCount() <= 0) {
             return 0;
@@ -252,6 +296,41 @@ public class ItemUtils {
         }
 
         return cAmt;
+    }
+
+    private static int damageAllInternal(IItemHandlerModifiable handler, Int2ObjectMap<ItemStack> contents, int maxOperations, int damagePerUse) {
+        int operations = 0;
+        if (damagePerUse <= 0) {
+            return 0;
+        }
+        for (final Int2ObjectMap.Entry<ItemStack> content : contents.int2ObjectEntrySet()) {
+            int slot = content.getIntKey();
+            ItemStack stack = content.getValue();
+            if (stack.isEmpty() || !stack.isItemStackDamageable() || stack.getMaxDamage() <= 0) {
+                continue;
+            }
+
+            while (operations < maxOperations && !stack.isEmpty()) {
+                int newDamage = stack.getItemDamage() + damagePerUse;
+                if (newDamage >= stack.getMaxDamage()) {
+                    stack.shrink(1);
+                    if (!stack.isEmpty()) {
+                        stack.setItemDamage(0);
+                    }
+                } else {
+                    stack.setItemDamage(newDamage);
+                }
+                operations++;
+            }
+
+            handler.setStackInSlot(slot, stack);
+
+            if (operations >= maxOperations) {
+                break;
+            }
+        }
+
+        return operations;
     }
 
     public static boolean stackEqualsNonNBT(@Nonnull ItemStack stack, @Nonnull ItemStack other) {


### PR DESCRIPTION
作出以下改动：

- 根据[RetroFuturaGradle](https://github.com/GTNewHorizons/RetroFuturaGradle)的最新配置，修改build.gradle.kts与settings.gradle.kts，解决GTNH Gradle链接变动导致的无法构建问题。我不确定这样做是否是正确的、必要的，但不改似乎无法正常导入Gradle项目
- 添加新的RecipePrimer“consumeDurability(int)”，用于消耗输入物品的耐久。若物品本身没有耐久度（比如普通的石头），则显示警告
