### PR TITLE
Properly handle lighting engine for Alfheim v1.6+

### DIFF
--- a/src/api/java/dev/redstudio/alfheim/lighting/LightingEngine.java
+++ b/src/api/java/dev/redstudio/alfheim/lighting/LightingEngine.java
@@ -1,0 +1,5 @@
+package dev.redstudio.alfheim.lighting;
+
+// stub class for Alfheim v1.6+
+public class LightingEngine {
+}

--- a/src/main/java/com/cleanroommc/client/util/TrackedDummyWorld.java
+++ b/src/main/java/com/cleanroommc/client/util/TrackedDummyWorld.java
@@ -1,7 +1,6 @@
 package com.cleanroommc.client.util;
 
 import com.cleanroommc.client.util.world.DummyWorld;
-import hellfirepvp.modularmachinery.ModularMachinery;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntity;
@@ -12,11 +11,9 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nonnull;
 import javax.vecmath.Vector3f;
-import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
@@ -40,26 +37,10 @@ public class TrackedDummyWorld extends DummyWorld {
 
     public TrackedDummyWorld() {
         proxyWorld = null;
-        initAlfheimLightingEngine();
     }
 
     public TrackedDummyWorld(World world) {
         proxyWorld = world;
-        initAlfheimLightingEngine();
-    }
-
-    private void initAlfheimLightingEngine() {
-        try {
-            Field lightingEngineField = World.class.getDeclaredField("alfheim$lightingEngine");
-            lightingEngineField.setAccessible(true);
-
-            if (lightingEngineField.get(this) == null) {
-                lightingEngineField.set(this, new AtomicReference<>());
-            }
-        } catch (NoSuchFieldException ignored) {
-        } catch (IllegalAccessException e) {
-            ModularMachinery.log.error("Failed to initialize Alfheim lighting engine: ", e);
-        }
     }
 
     public void setRenderFilter(Predicate<BlockPos> renderFilter) {

--- a/src/main/java/com/cleanroommc/client/util/world/DummyWorld.java
+++ b/src/main/java/com/cleanroommc/client/util/world/DummyWorld.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.client.util.world;
 
+import dev.redstudio.alfheim.lighting.LightingEngine;
 import hellfirepvp.modularmachinery.ModularMachinery;
 import hellfirepvp.modularmachinery.common.base.Mods;
 import net.minecraft.block.Block;
@@ -27,7 +28,6 @@ public class DummyWorld extends World {
 
     private static final WorldSettings DEFAULT_SETTINGS = new WorldSettings(1L, GameType.SURVIVAL, true, false, WorldType.DEFAULT);
 
-    @SuppressWarnings("deprecation")
     public DummyWorld() {
         super(new DummySaveHandler(), new WorldInfo(DEFAULT_SETTINGS, "DummyServer"), new WorldProviderSurface(), new Profiler(), true);
         // Guarantee the dimension ID was not reset by the provider
@@ -117,13 +117,19 @@ public class DummyWorld extends World {
 
     @Override
     @Optional.Method(modid = "alfheim")
-    public int getLightFromNeighborsFor(EnumSkyBlock type, BlockPos pos) {
+    public int getLightFromNeighborsFor(@Nonnull EnumSkyBlock type, @Nonnull BlockPos pos) {
         return 15;
     }
 
+    @SuppressWarnings("unused")
     @Optional.Method(modid = "alfheim")
     public int alfheim$getLight(BlockPos pos, boolean checkNeighbors) {
         return 15;
     }
 
+    @SuppressWarnings("unused")
+    @Optional.Method(modid = "alfheim")
+    public LightingEngine getAlfheim$lightingEngine() {
+        return null;
+    }
 }


### PR DESCRIPTION
Supersedes/reverts #171. That PR allowed Alfheim 1.6 to create its lighting engine to fix the crash. This PR ensures the lighting engine is not created, just like with previous versions. Older versions of Alfheim should still be compatible.
(same changes as https://github.com/GregTechCEu/GregTech/pull/2838)