### PR TITLE
fix: 修复不可堆叠物品在输出时被堆叠的问题

### DIFF
--- a/src/main/java/hellfirepvp/modularmachinery/common/util/ItemUtils.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/util/ItemUtils.java
@@ -273,7 +273,8 @@ public class ItemUtils {
 
         int inserted = 0;
         for (int i = 0; i < handler.getSlots(); i++) {
-            int maxStackSize = handler.getSlotLimit(i);
+            // 避免不可堆叠物品被叠加
+            int maxStackSize = Math.min(handler.getSlotLimit(i), stack.getMaxStackSize());
             ItemStack in = handler.getStackInSlot(i);
             int count = in.getCount();
             if (count >= maxStackSize) {
@@ -285,7 +286,8 @@ public class ItemUtils {
                 handler.setStackInSlot(i, copyStackWithSize(stack, toInsert));
                 inserted += toInsert;
             } else {
-                if (stackEqualsNonNBT(stack, in) && matchTags(stack, in)) {
+                // 不允许对不可堆叠物品进行合并
+                if (stack.isStackable() && stackEqualsNonNBT(stack, in) && matchTags(stack, in)) {
                     int toInsert = Math.min(maxInsert - inserted, maxStackSize - count);
                     handler.setStackInSlot(i, copyStackWithSize(stack, toInsert + count));
                     inserted += toInsert;


### PR DESCRIPTION
插入逻辑现在会受物品最大堆叠数约束，并禁止对不可堆叠物品执行合并，避免物品输出仓内出现异常堆叠