### PR TITLE
fix: 修复JEI插件注册失败导致无法检索配方

### DIFF
--- a/src/main/java/hellfirepvp/modularmachinery/common/integration/ModIntegrationJEI.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/integration/ModIntegrationJEI.java
@@ -206,10 +206,12 @@ public class ModIntegrationJEI implements IModPlugin {
             registry.addRecipeCatalyst(stack, machineCategory);
         }
 
-        // Only handle MM recipes
-        for (DynamicMachine machine : MachineRegistry.getRegistry()) {
-            String machineCategory = getCategoryStringFor(machine);
-            registry.getRecipeTransferRegistry().addRecipeTransferHandler(new MEInputRecipeTransferHandler(), machineCategory);
+        // 仅在 AE2 存在时注册转移处理器，避免类加载失败导致 JEI 插件注册中断
+        if (Mods.AE2.isPresent()) {
+            for (DynamicMachine machine : MachineRegistry.getRegistry()) {
+                String machineCategory = getCategoryStringFor(machine);
+                registry.getRecipeTransferRegistry().addRecipeTransferHandler(new MEInputRecipeTransferHandler(), machineCategory);
+            }
         }
 
         for (DynamicMachine machine : MachineRegistry.getRegistry()) {


### PR DESCRIPTION
问题说明
- 在未安装 AE2 的环境下，JEI 初始化时注册配方转移处理器会触发 ContainerMEItemInputBus 类加载，导致 NoClassDefFoundError，从而使 ModularMachinery 的 JEI 插件注册失败，最终无法在 JEI 中检索配方。

修复内容
- 仅当检测到 AE2 存在时才注册 ME 输入总线的配方转移处理器，避免在无 AE2 环境下的类加载错误。

影响范围
- 不影响安装了 AE2 的场景。
- 无 AE2 时恢复 JEI 配方正常注册与检索。

测试说明
- 本地通过启动客户端验证 JEI 配方检索恢复正常。
