### PR TITLE
Add a config to change the ME Hatch base size for Fluid/Gas

### DIFF
--- a/src/main/java/github/kasuminova/mmce/common/container/ContainerMEFluidBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/container/ContainerMEFluidBus.java
@@ -25,11 +25,14 @@ public abstract class ContainerMEFluidBus extends ContainerUpgradeable implement
     private final   MEFluidBus      owner;
     @GuiSync(7)
     public          int             capacityUpgrades = 0;
+    @GuiSync(8)
+    public          int             tankCapacity = 0;
 
     public ContainerMEFluidBus(final InventoryPlayer ip, final MEFluidBus te) {
         super(ip, te);
         this.owner = te;
         this.tankSync = new FluidSyncHelper(owner.getTanks(), 0);
+        this.tankCapacity = ((AEFluidInventoryUpgradeable) owner.getTanks()).getCapacity();
     }
 
     @Override
@@ -73,6 +76,11 @@ public abstract class ContainerMEFluidBus extends ContainerUpgradeable implement
             if (capacityUpgrades != installedUpgrades) {
                 capacityUpgrades = installedUpgrades;
             }
+
+            int currentTankCapacity = ((AEFluidInventoryUpgradeable) this.owner.getTanks()).getCapacity();
+            if (this.tankCapacity != currentTankCapacity) {
+                this.tankCapacity = currentTankCapacity;
+            }
         }
 
         super.detectAndSendChanges();
@@ -81,11 +89,22 @@ public abstract class ContainerMEFluidBus extends ContainerUpgradeable implement
     @Override
     public void onUpdate(final String field, final Object oldValue, final Object newValue) {
         super.onUpdate(field, oldValue, newValue);
-        if (Platform.isClient() && field.equals("capacityUpgrades")) {
-            this.capacityUpgrades = (int) newValue;
-            ((AEFluidInventoryUpgradeable) this.owner.getTanks()).setCapacity(
-                (int) (Math.pow(4, this.capacityUpgrades + 1) * (MEFluidBus.TANK_DEFAULT_CAPACITY / 4)));
+
+        if (!Platform.isClient()) {
+            return;
         }
+
+        if ("capacityUpgrades".equals(field)) {
+            this.capacityUpgrades = (int) newValue;
+            return;
+        }
+
+        if (!"tankCapacity".equals(field)) {
+            return;
+        }
+
+        this.tankCapacity = (int) newValue;
+        ((AEFluidInventoryUpgradeable) this.owner.getTanks()).setCapacity(this.tankCapacity);
     }
 
     @Override

--- a/src/main/java/github/kasuminova/mmce/common/container/ContainerMEGasBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/container/ContainerMEGasBus.java
@@ -10,7 +10,6 @@ import appeng.util.Platform;
 import com.mekeng.github.common.container.sync.IGasSyncContainer;
 import com.mekeng.github.common.me.data.IAEGasStack;
 import com.mekeng.github.util.helpers.GasSyncHelper;
-import github.kasuminova.mmce.common.tile.base.MEFluidBus;
 import github.kasuminova.mmce.common.tile.base.MEGasBus;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IContainerListener;
@@ -27,10 +26,14 @@ public abstract class ContainerMEGasBus extends ContainerUpgradeable implements 
     @GuiSync(7)
     public int capacityUpgrades = 0;
 
+    @GuiSync(8)
+    public int tankCapacity = 0;
+
     public ContainerMEGasBus(final InventoryPlayer ip, final MEGasBus te) {
         super(ip, te);
         this.owner = te;
         this.tankSync = GasSyncHelper.create(owner.getTanks(), 0);
+        this.tankCapacity = owner.getTankCapacity();
     }
 
     @Override
@@ -74,6 +77,11 @@ public abstract class ContainerMEGasBus extends ContainerUpgradeable implements 
             if (capacityUpgrades != installedUpgrades) {
                 capacityUpgrades = installedUpgrades;
             }
+
+            int currentTankCapacity = this.owner.getTankCapacity();
+            if (this.tankCapacity != currentTankCapacity) {
+                this.tankCapacity = currentTankCapacity;
+            }
         }
 
         super.detectAndSendChanges();
@@ -82,12 +90,22 @@ public abstract class ContainerMEGasBus extends ContainerUpgradeable implements 
     @Override
     public void onUpdate(final String field, final Object oldValue, final Object newValue) {
         super.onUpdate(field, oldValue, newValue);
-        if (Platform.isClient() && field.equals("capacityUpgrades")) {
-            this.capacityUpgrades = (int) newValue;
-            this.owner.getTanks().setCap(
-                (int) (Math.pow(4, this.capacityUpgrades + 1) * (MEFluidBus.TANK_DEFAULT_CAPACITY / 4))
-            );
+
+        if (!Platform.isClient()) {
+            return;
         }
+
+        if ("capacityUpgrades".equals(field)) {
+            this.capacityUpgrades = (int) newValue;
+            return;
+        }
+
+        if (!"tankCapacity".equals(field)) {
+            return;
+        }
+
+        this.tankCapacity = (int) newValue;
+        this.owner.getTanks().setCap(this.tankCapacity);
     }
 
     @Override

--- a/src/main/java/github/kasuminova/mmce/common/tile/base/MEFluidBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/tile/base/MEFluidBus.java
@@ -15,6 +15,7 @@ import appeng.util.IConfigManagerHost;
 import appeng.util.inv.IAEAppEngInventory;
 import appeng.util.inv.InvOperation;
 import github.kasuminova.mmce.common.util.AEFluidInventoryUpgradeable;
+import hellfirepvp.modularmachinery.common.data.Config;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.item.ItemStack;
@@ -40,7 +41,7 @@ public abstract class MEFluidBus extends MEMachineComponent implements
     IGridTickable {
 
     public static final int TANK_SLOT_AMOUNT      = 9;
-    public static final int TANK_DEFAULT_CAPACITY = 8000;
+    public static       int TANK_DEFAULT_CAPACITY = Config.meFluidBusBaseCapacity;
 
     protected final IFluidStorageChannel        channel           = AEApi.instance().storage().getStorageChannel(IFluidStorageChannel.class);
     protected final ConfigManager               cm                = new ConfigManager(this);
@@ -53,9 +54,31 @@ public abstract class MEFluidBus extends MEMachineComponent implements
     protected       boolean                     inTick            = false;
 
     public MEFluidBus() {
-        this.tanks = new AEFluidInventoryUpgradeable(this, TANK_SLOT_AMOUNT, TANK_DEFAULT_CAPACITY);
+        this.tanks = new AEFluidInventoryUpgradeable(this, TANK_SLOT_AMOUNT, getBaseTankCapacity());
         this.upgrades = new StackUpgradeInventory(proxy.getMachineRepresentation(), this, 5);
         this.changedSlots = new boolean[TANK_SLOT_AMOUNT];
+    }
+
+    public static int getBaseTankCapacity() {
+        TANK_DEFAULT_CAPACITY = Math.max(1, Config.meFluidBusBaseCapacity);
+        return TANK_DEFAULT_CAPACITY;
+    }
+
+    public static int calculateTankCapacity(final int capacityUpgrades) {
+        long capacity = getBaseTankCapacity();
+        int remainingUpgrades = Math.max(0, capacityUpgrades);
+
+        // Capacity cards multiply tank size by four, so clamp before the next step would overflow.
+        while (remainingUpgrades > 0) {
+            if (capacity > Integer.MAX_VALUE / 4L) {
+                return Integer.MAX_VALUE;
+            }
+
+            capacity *= 4L;
+            remainingUpgrades--;
+        }
+
+        return (int) capacity;
     }
 
     protected synchronized int[] getNeedUpdateSlots() {
@@ -146,8 +169,7 @@ public abstract class MEFluidBus extends MEMachineComponent implements
     }
 
     private void updateTankCapacity() {
-        tanks.setCapacity(
-            (int) (Math.pow(4, getInstalledUpgrades(Upgrades.CAPACITY) + 1) * (MEFluidBus.TANK_DEFAULT_CAPACITY / 4)));
+        tanks.setCapacity(calculateTankCapacity(getInstalledUpgrades(Upgrades.CAPACITY)));
     }
 
     @Override

--- a/src/main/java/github/kasuminova/mmce/common/tile/base/MEGasBus.java
+++ b/src/main/java/github/kasuminova/mmce/common/tile/base/MEGasBus.java
@@ -16,6 +16,7 @@ import com.mekeng.github.common.me.inventory.IGasInventoryHost;
 import com.mekeng.github.common.me.inventory.impl.GasInventory;
 import com.mekeng.github.common.me.storage.IGasStorageChannel;
 import github.kasuminova.mmce.common.util.GasInventoryHandler;
+import hellfirepvp.modularmachinery.common.data.Config;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import mekanism.api.gas.IGasHandler;
@@ -40,7 +41,7 @@ public abstract class MEGasBus extends MEMachineComponent implements
     IGridTickable {
 
     public static final int TANK_SLOT_AMOUNT      = 9;
-    public static final int TANK_DEFAULT_CAPACITY = 8000;
+    public static       int TANK_DEFAULT_CAPACITY = Config.meGasBusBaseCapacity;
 
     protected final IGasStorageChannel  channel           = AEApi.instance().storage().getStorageChannel(IGasStorageChannel.class);
     protected final ConfigManager       cm                = new ConfigManager(this);
@@ -53,10 +54,32 @@ public abstract class MEGasBus extends MEMachineComponent implements
     protected boolean inTick = false;
 
     public MEGasBus() {
-        this.tanks = new GasInventory(TANK_SLOT_AMOUNT, TANK_DEFAULT_CAPACITY, this);
+        this.tanks = new GasInventory(TANK_SLOT_AMOUNT, getBaseTankCapacity(), this);
         this.handler = new GasInventoryHandler(tanks);
         this.upgrades = new StackUpgradeInventory(proxy.getMachineRepresentation(), this, 5);
         this.changedSlots = new boolean[TANK_SLOT_AMOUNT];
+    }
+
+    public static int getBaseTankCapacity() {
+        TANK_DEFAULT_CAPACITY = Math.max(1, Config.meGasBusBaseCapacity);
+        return TANK_DEFAULT_CAPACITY;
+    }
+
+    public static int calculateTankCapacity(final int capacityUpgrades) {
+        long capacity = getBaseTankCapacity();
+        int remainingUpgrades = Math.max(0, capacityUpgrades);
+
+        // Capacity cards multiply tank size by four, so clamp before the next step would overflow.
+        while (remainingUpgrades > 0) {
+            if (capacity > Integer.MAX_VALUE / 4L) {
+                return Integer.MAX_VALUE;
+            }
+
+            capacity *= 4L;
+            remainingUpgrades--;
+        }
+
+        return (int) capacity;
     }
 
     protected synchronized int[] getNeedUpdateSlots() {
@@ -77,6 +100,10 @@ public abstract class MEGasBus extends MEMachineComponent implements
 
     public GasInventory getTanks() {
         return tanks;
+    }
+
+    public int getTankCapacity() {
+        return tanks.getTanks()[0].getMaxGas();
     }
 
     @Override
@@ -155,8 +182,7 @@ public abstract class MEGasBus extends MEMachineComponent implements
     }
 
     private void updateTankCapacity() {
-        tanks.setCap(
-            (int) (Math.pow(4, getInstalledUpgrades(Upgrades.CAPACITY) + 1) * (MEGasBus.TANK_DEFAULT_CAPACITY / 4)));
+        tanks.setCap(calculateTankCapacity(getInstalledUpgrades(Upgrades.CAPACITY)));
     }
 
     @Override

--- a/src/main/java/hellfirepvp/modularmachinery/common/data/Config.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/data/Config.java
@@ -43,6 +43,8 @@ public class Config {
     public static boolean asyncControllerModelRender         = true;
     public static boolean enableDurationMultiplier           = true;
     public static int     machineColor;
+    public static int     meFluidBusBaseCapacity             = 8000;
+    public static int     meGasBusBaseCapacity               = 8000;
     public static int     maxMachineParallelism              = 2048;
     public static int     defaultFactoryMaxThread            = 20;
 
@@ -107,6 +109,18 @@ public class Config {
         // FluxNetworks Integration
         enableFluxNetworksIntegration = lastReadConfig.getBoolean("enable-fluxnetworks-integration", "general", true,
             "When enabled, allows you to use the flux network to transfer larger amounts of energy than 2147483647.");
+
+        // Base Capacity of ME Buses
+        meFluidBusBaseCapacity = lastReadConfig.getInt(
+            "me-fluid-bus-base-capacity", "general",
+            8000, 1, Integer.MAX_VALUE,
+            "The base tank capacity of each ME Fluid Bus slot before Capacity Card multipliers are applied. The final per-slot capacity clamps at Integer.MAX_VALUE."
+        );
+        meGasBusBaseCapacity = lastReadConfig.getInt(
+            "me-gas-bus-base-capacity", "general",
+            8000, 1, Integer.MAX_VALUE,
+            "The base tank capacity of each ME Gas Bus slot before Capacity Card multipliers are applied. The final per-slot capacity clamps at Integer.MAX_VALUE."
+        );
 
         // Parallelize Feature
         machineParallelizeEnabledByDefault = lastReadConfig.getBoolean("machine-parallelize-enabled-bydefault",


### PR DESCRIPTION
Allow to change the base size that is multiplied by the capacity cards (protected against overflow). While the default size is usually sufficient for most "normal" recipes, it is often a pain point for higher quantities (requiring multiple capacity cards, or even requiring the modpack maker to reduce the max due to not having enough space).
The ideal would be to align Item and Fluid ME hatches, but it would be a much bigger rework.