### PR TITLE
修复机器结构切换后运行中配方残留的问题

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("maven-publish")
     id("org.jetbrains.gradle.plugin.idea-ext") version "1.1.7"
     id("eclipse")
-    id("com.gtnewhorizons.retrofuturagradle") version "1.4.0"
+    id("com.gtnewhorizons.retrofuturagradle") version "1.4.1"
 }
 
 // Project properties

--- a/src/main/java/hellfirepvp/modularmachinery/common/tiles/base/TileMultiblockMachineController.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/tiles/base/TileMultiblockMachineController.java
@@ -396,7 +396,9 @@ public abstract class TileMultiblockMachineController extends TileEntityRestrict
         }
         updateStatedMachineComponentSync(false);
 
-        prevMachine = foundMachine;
+        if (foundMachine != null) {
+            prevMachine = foundMachine;
+        }
         foundMachine = null;
         foundPattern = null;
         foundReplacements = null;


### PR DESCRIPTION
## 概述

本 PR 修复一个多方块机器结构切换时，运行中配方没有被正确清理的问题。

同时将 RetroFuturaGradle 从 `1.4.0` 更新到 `1.4.1`，因为当前远端已无法获取 `1.4.0`，会导致项目无法正常构建。

## 问题描述

如果存在两个结构几乎相同的机器 A 和机器 B：

1. 搭建机器 A；
2. 启动机器 A 的某个配方，产物为物品 A；
3. 在配方完成前拆掉一个结构方块，使机器结构失效；
4. 替换该方块，使控制器重新匹配为机器 B；
5. 此时旧的机器 A 配方仍可能继续完成，并产出物品 A。

也就是说，机器结构已经从 A 切换到了 B，但旧的运行中配方上下文仍然残留。

## 原因

结构失效时，`resetMachine(true)` 会将当前机器记录到 `prevMachine`。

但同一次结构检查流程中，后续还可能调用 `resetMachine(false)`。此时 `foundMachine` 已经是 `null`，导致 `prevMachine` 被覆盖成 `null`。

这样当新结构重新形成时，`onStructureFormed()` 无法判断机器已经从 A 切换到 B，因此没有调用 `resetRecipe()` 清理旧配方。

## 修改内容

- 避免在 `foundMachine == null` 时覆盖 `prevMachine`；
- 使机器 A -> 结构失效 -> 机器 B 的切换流程能够正确清理旧的运行中配方；
- 将 `com.gtnewhorizons.retrofuturagradle` 从 `1.4.0` 更新到 `1.4.1`，修复构建依赖无法下载的问题。

## 测试

- 已在游戏内验证：机器 A 运行中改造成机器 B 后，不再产出机器 A 的旧配方结果；
- 已运行编译：

```bash
./gradlew.bat compileJava